### PR TITLE
Rewrite README with meal-kit philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Config and all synced data live under `~/.obk/` (override with `OBK_CONFIG_DIR`)
 
 ## Prerequisites
 
+- macOS (OpenBotKit is built with macOS as the primary target)
 - Go 1.25+
 - Gmail requires API credentials from [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
 - WhatsApp requires scanning a QR code to link your phone
-- Apple Notes requires macOS (uses AppleScript, no special permissions needed)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrites README around the core idea: OpenBotKit is a meal kit, not a meal
- Leads with "Why" section covering safety, local-first data, no intermediary, full visibility
- Adds "What's in the kit" table for quick overview
- Moves full CLI reference into a collapsible `<details>` block
- Removes library usage section (nobody is using it as a Go library)
- Includes Apple Notes in all relevant sections

## Test plan
- [x] Verify README renders correctly on GitHub