### PR TITLE
docs: project-wide testing strategy

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,67 +1,53 @@
 # Testing Strategy
 
-## Why this exists
+## Tests are how we understand the project
 
-openbotkit is a personal AI agent that crosses many layers — LLM providers, tool execution, skill discovery, bash commands, SQLite databases, messaging channels. A bug anywhere in this chain silently degrades the user experience. We need confidence at every level: that individual functions work, that components integrate correctly, and that the agent can actually complete a user's task end-to-end.
+Tests are the most essential part of this application. They are not an afterthought or a chore — they are how we document what the system does, how its parts fit together, and how the user experiences it. If you want to understand how openbotkit works, read the tests. If the tests don't make that clear, the tests are wrong.
 
-This document describes how we think about testing across the project, from fast isolated unit tests up to full LLM-driven spec tests.
+Every test must have a **point of view**. It must be clear who is doing the observing and what question is being answered. A test without a perspective is a garbage test — it might pass, it might fail, but it doesn't tell you anything.
 
-## The testing pyramid
+We avoid vague labels like "e2e" because they don't mean anything on their own. End-to-end of what? From whose perspective? Instead, every test level in this project is defined by its perspective and the question it answers.
 
-```
-        Spec Tests
-        Prove the agent completes real user tasks
-        Real LLMs, real databases, LLM-judged assertions
+## The five perspectives
 
-      Provider Conformance Tests
-      Each LLM provider drives the agent protocol correctly
+### 1. Unit tests — the author's perspective
 
-    Session Integration Tests
-    Message → agent → response → storage pipeline
+**Question:** Does this piece of logic do what I, the author, intended?
 
-  Server API Contract Tests
-  HTTP API endpoints honor their contracts
+Unit tests are written from the perspective of the developer who wrote the code. You're testing a function, a method, a small unit of logic. You control all inputs, you mock everything external, and you verify that the logic is correct in isolation.
 
-Unit Tests (the base)
-Individual functions in isolation, fast and deterministic
-```
+The point of reference is **the code itself**. If `extractContent` receives a protobuf message with an image caption, it should return that caption and `"image"` as the media type. If the retry wrapper gets a 429, it should retry. If it gets a 401, it should not. These tests don't know or care about the rest of the system.
 
-Each level tests something the level below cannot. We don't skip levels — a spec test passing doesn't excuse a missing unit test for the function it exercises.
+This is where we have the most tests. They're fast, deterministic, and cheap. They run in-memory with mocks, stubs, and `t.TempDir()`. No network, no real databases, no LLM calls.
 
-## Unit tests
+**What makes a good unit test here:**
+- It tests one decision the code makes, not a chain of decisions across modules.
+- The test name describes the behavior, not the implementation: `TestRetry_429Retries` not `TestRetryFunction`.
+- Mocks are defined in the same test file, not in shared packages. `mockProvider`, `mockBot`, `stubTool` — they live next to what they test.
 
-**What they cover:** Individual functions with no external dependencies. Mocks, stubs, and in-memory SQLite databases keep them fast and deterministic.
+**Examples:**
+- `agent/agent_test.go` — the agent loop with a scripted mock provider. Does it handle tool calls? Does it stop at max iterations? Does it scrub secrets from tool output?
+- `memory/store_test.go` — CRUD operations on an in-memory SQLite database. Does dedup work? Does search return the right results?
+- `channel/telegram/telegram_test.go` — does Send format Markdown correctly? Does the owner filter reject non-owners?
+- `provider/resilient_test.go` — does the retry wrapper honor 429 vs 401 vs max retries?
 
-**Examples across the project:**
+### 2. Contract tests — the consumer's perspective
 
-| Area | What's tested | Pattern |
-|------|--------------|---------|
-| `agent/agent_test.go` | Agent loop: text responses, tool calls, multi-tool sequences, max iterations, secret scrubbing, history compaction | `mockProvider` returns scripted LLM responses; `mockExecutor` records tool calls |
-| `agent/tools/tools_test.go` | Tool registry, bash execution (echo, timeout, stderr), file operations, output truncation (524KB limit) | Direct function calls with temp directories |
-| `provider/resilient_test.go` | Retry logic: 429 retries, 401 doesn't retry, max retries respected | Mock HTTP responses |
-| `provider/ratelimit_test.go` | Burst allowance, context cancellation | Time-based assertions |
-| `provider/credential_test.go` | Keyring parsing, store/load, env var fallback | Isolated credential operations |
-| `memory/store_test.go` | CRUD, list, search, count, duplicate handling | In-memory SQLite via `testDB()` |
-| `memory/schema_test.go` | Migration idempotency | Run migration twice, verify no error |
-| `source/whatsapp/sync_test.go` | Content extraction from protobuf message types, text truncation | Direct function calls with proto builders |
-| `source/whatsapp/send_test.go` | JID validation, group detection, message upsert, dedup | In-memory SQLite |
-| `source/gmail/store_test.go` | Email CRUD | In-memory SQLite |
-| `channel/telegram/telegram_test.go` | Send (Markdown formatting), receive (EOF on close), approval keyboard, owner filtering | `mockBot` captures sent messages |
-| `config/config_test.go` | Defaults, path DSN generation, YAML loading | File-based config in temp dirs |
-| `internal/skills/` | Manifest parsing, skill indexing, skill installation | Temp directories with fixture files |
+**Question:** Does this service honor the promises it makes to its consumers?
 
-**Conventions:**
-- All database tests use in-memory SQLite or `t.TempDir()` — no shared state between tests.
-- Mocks are defined in the test file that uses them, not in shared packages. `mockProvider`, `mockExecutor`, `mockBot`, and `stubTool` each live next to their tests.
-- No test frameworks beyond the standard `testing` package. Assertions are manual `if err != nil` checks with `t.Fatalf`.
+Contract tests are written from the perspective of someone who depends on a boundary — an HTTP API, an interface, a protocol. They don't test internal logic. They test that when you call the API in a valid way, you get the right response, and when you call it in an invalid way, you get the right error.
 
-## Server API contract tests
+The point of reference is **the contract between two systems**. The server promises: "POST /api/memory with a valid body and auth token creates a memory and returns 200." The contract test verifies that promise holds regardless of what's behind the API.
 
-**What they prove:** The HTTP API endpoints accept valid requests, reject invalid ones, enforce authentication, and return correct responses.
+**Server API contract tests** (`internal/servertest/suite.go`):
 
-**Location:** `internal/servertest/suite.go` defines the test suite. `internal/server/api_test.go` runs it against a local httptest server.
+The suite is written from the perspective of a client consuming the server's HTTP API. It tests:
+- Health checks work without authentication.
+- Memory CRUD works with authentication and rejects without it.
+- The database proxy rejects non-SELECT queries.
+- Send endpoints validate their inputs.
 
-**How it works:**
+The suite doesn't know the server's internals. It talks to a `Backend` struct with an HTTP client and a `SeedDB` callback for injecting test state. `internal/server/api_test.go` wires this to a real httptest server.
 
 ```go
 backend := servertest.Backend{
@@ -72,134 +58,101 @@ backend := servertest.Backend{
 servertest.Run(t, backend)
 ```
 
-The suite tests:
-- Health checks work without authentication
-- Memory CRUD (add, list, filter by category, delete)
-- Authentication enforcement (memory operations rejected without auth)
-- Apple Notes push and query (upsert behavior)
-- Database proxy (rejects non-SELECT queries, rejects unknown sources)
-- Gmail/WhatsApp send validation
-- Raw database seeding and querying
+### 3. Conformance tests — the protocol's perspective
 
-The `SeedDB` callback lets the suite inject test data directly into SQLite, independent of API endpoints. This means the suite tests the API layer's behavior, not the database layer's.
+**Question:** Does this implementation conform to the behavioral contract that all implementations must satisfy?
 
-## Provider conformance tests
+Conformance tests are written from the perspective of the protocol or interface that multiple implementations must honor. We have one agent protocol — tool calls, tool results, streaming — and four LLM providers (Anthropic, Anthropic Vertex, OpenAI, Gemini). Each provider has its own quirks: Gemini needs function names on tool results, OpenAI streams differently, Anthropic Vertex requires project IDs. But from the agent's perspective, they all must behave the same way.
 
-**What they prove:** Each LLM provider implementation correctly drives the agent protocol — tool calls are emitted, tool results are consumed, streaming works.
+The point of reference is **the shared contract**. The same test runs against every provider:
 
-**Location:** `agent/provider_test.go`
+- `TestProvider_AgentToolExecution` — the provider drives the agent loop: tool call → execution → final response.
+- `TestProvider_ToolUseRoundtrip` — tool_use → tool_result → text_response cycle.
+- `TestProvider_Streaming` — text deltas arrive followed by a done event.
 
-**Tests:**
-- `TestProvider_AgentToolExecution` — provider drives the full agent loop (tool call → execution → final response)
-- `TestProvider_ToolUseRoundtrip` — tool_use → tool_result → text_response cycle
-- `TestProvider_Streaming` — text deltas arrive followed by a done event
+`EachProvider(t, ...)` runs the test for every provider that has credentials set. Missing credentials skip, not fail. This is how we catch regressions in one provider without touching the others.
 
-**Multi-provider execution:** Tests run for every available provider (Anthropic, Anthropic Vertex, OpenAI, Gemini) using an `EachProvider` helper. If credentials aren't set, that provider is skipped — not failed.
+### 4. Integration tests — the boundary's perspective
 
-This catches provider-specific quirks: Gemini needing function names on tool results, OpenAI streaming differently, Anthropic Vertex requiring project IDs. Same behavioral contract, different implementations.
+**Question:** When these two bounded contexts work together, does the combined behavior make sense?
 
-## Session integration tests
+Integration tests are written from the perspective of the **boundary between two systems**. Not "does the agent work" and not "does the database work" — but "when a Telegram message arrives, does it flow through the agent and come back as a bot reply with history saved?"
 
-**What they prove:** The full message → agent → response → storage pipeline works for each messaging channel.
+The point of reference is **the seam where two contexts meet**. A Telegram session connects the channel (messages in, replies out) with the agent (LLM reasoning, tool execution) and storage (conversation history, memories). The integration test verifies these pieces compose correctly.
 
-**Locations:** `channel/telegram/integration_test.go`, `source/whatsapp/integration_test.go`
+**Session integration tests** (`channel/telegram/integration_test.go`, `source/whatsapp/integration_test.go`):
 
-**Telegram examples:**
-- `TestSession_MessageAndHistorySaved` — message goes in, Gemini produces a response, the response is sent via bot, and conversation history is saved to SQLite.
-- `TestSession_MemoryInjectedIntoPrompt` — memories from the database appear in the system prompt the LLM receives.
-- `TestSession_ToolUseViaBash` — agent executes bash commands during a session and the results flow back.
+- `TestSession_MessageAndHistorySaved` — a message enters through the Telegram channel, the agent (with a real LLM) produces a response, the mock bot captures the reply, and the history database has the conversation.
+- `TestSession_MemoryInjectedIntoPrompt` — memories from the database appear in the system prompt. This tests that the session correctly bridges the memory store and the LLM provider.
+- `TestSession_ToolUseViaBash` — the agent executes bash commands during a session. This tests that tool execution is wired through correctly from channel to agent to tools and back.
 
-**Setup pattern:** Each test creates a temp config directory, migrates history and memory databases, creates a channel with a mock bot, and wires a real LLM provider. The mock bot captures `Send()` calls so we can verify what the user would see.
+Each test creates an isolated environment: temp config directory, migrated databases, mock bot, real LLM provider. The mock bot is the observation point — we verify what the user would actually see.
 
-These tests use real LLM APIs (currently Gemini) and skip if credentials are absent.
+These use real LLM APIs and skip if credentials are absent.
 
-## Spec tests
+### 5. Spec tests — the user's perspective
 
-**What they prove:** The agent can complete real user tasks end-to-end — discover skills, query databases, combine information from multiple sources, and produce useful answers.
+**Question:** Can the agent actually do what the user needs it to do?
 
-**Location:** `spectest/`
+Spec tests are written from the perspective of the **user**. Not the developer, not the API consumer, not the protocol — the person who types "find emails from Alice" and expects a useful answer. This is the most important perspective and the hardest to test.
 
-This is the highest-value, highest-cost testing layer. Unit tests can't catch "the agent asks the LLM for a SQL query but the skill prompt is wrong." Integration tests can't catch "the agent finds emails but fails to also check WhatsApp when asked about all communications." Spec tests can.
+The point of reference is **the user's task**. The user doesn't know about tool registries, skill loading, SQL queries, or bash execution. They know: "I asked for emails from Alice and got them" or "I asked for a summary of all communications and got something useful."
 
-### Core ideas
+**Why this level exists:** Unit tests can't catch "the skill prompt teaches the LLM wrong SQL." Integration tests can't catch "the agent finds emails but forgets to also check WhatsApp when asked about all communications." Only a test written from the user's perspective can catch these, because only that perspective sees the full chain from question to answer.
 
-**Test user behavior, not implementation.** The spec is "find emails from Alice" or "summarize communications across sources" — things the user does. Tests don't know how the agent routes through tools internally.
+**Core principles:**
 
-**Declarative state setup (Given pattern).** `fixture.GivenEmails(t, emails)` reads like a story. The fixture knows how to produce that state (insert into SQLite, install skills, build the CLI binary). The test doesn't care.
+**Test user behavior, not implementation.** The spec is "find emails from Alice" — not "call search_skills, then load_skills, then bash with a SQL query." If the agent finds a better route to the answer tomorrow, the test should still pass.
 
-**Same spec, multiple providers.** `EachProvider(t, func(t *testing.T, fx *LocalFixture) { ... })` runs the same behavioral test against Gemini, Anthropic Vertex, and OpenAI. Same assertions, different LLM backends.
+**Declarative state setup.** `fixture.GivenEmails(t, emails)` reads like a story. The fixture handles the machinery (SQLite inserts, skill installation, CLI binary builds). The test reads like a user scenario.
 
-### Fixture design
+**Same spec, multiple providers.** `EachProvider(t, func(t *testing.T, fx *LocalFixture) { ... })` runs the same user scenario against Gemini, Anthropic Vertex, and OpenAI. If the agent can find Alice's emails with Gemini but not OpenAI, that's a real bug.
 
-```go
-type Fixture interface {
-    Agent(t *testing.T) *agent.Agent
-    GivenEmails(t *testing.T, emails []Email)
-    GivenWhatsAppMessages(t *testing.T, messages []Message)
-    GivenMemories(t *testing.T, memories []Memory)
-}
-```
+**Current specs:**
 
-**Local fixture** (`local_fixture.go`):
-- `OBK_CONFIG_DIR` → `t.TempDir()` with real SQLite databases, migrated
-- Skills embedded and installed from source tree
-- `obk` binary built via `go build` and placed in PATH
-- `GivenEmails` → inserts rows directly into `gmail_emails` table
-- Agent wired with real tools (bash, skills) pointing at test databases
-- Provider → real LLM (env-gated)
+| Spec | The user's task |
+|------|----------------|
+| `TestSpec_FindEmailsBySender` | "Find emails from Alice" — agent discovers the right skill, queries the database, returns matching emails |
+| `TestSpec_SummarizeCommunicationsAcrossSources` | "Summarize all communications with Bob" — agent checks both email and WhatsApp, synthesizes across sources |
+| `TestSpec_RecallMemoryAndCorrelateEmails` | "What did I say I cared about, and are there relevant emails?" — agent combines personal memories with email search |
 
-### Assertion strategy
+**Assertion strategy for non-deterministic output:**
 
-The agent is non-deterministic — the LLM may phrase responses differently each run. But the data is deterministic: if the agent found the right email, the sender address and subject line appear verbatim.
+The LLM is non-deterministic but the data is deterministic. If the agent found the right email, `alice@example.com` appears verbatim in the response. Three assertion layers:
 
-Three layers, applied progressively:
+1. **Structural** — what did the agent *do*? Check tool call recordings and send recorders. Free and deterministic.
+2. **Substring on data** — does the response contain the database values the agent should have found? Free and deterministic.
+3. **LLM judge** — does the response *mean* the right thing? A cheap model evaluates semantic criteria. Used only when substring matching genuinely can't express the assertion.
 
-**Layer 1 — Structural (free, deterministic).** Check what the agent did, not what it said. Record tool calls. For send operations, check a recorder: was a message sent to the right recipient?
+## Practical guidelines
 
-**Layer 2 — Substring on data (free, deterministic).** The response should contain `alice@example.com` or `Meeting Tomorrow`. These are database values — the LLM retrieves them, it doesn't rephrase them.
+### When to write which test
 
-**Layer 3 — LLM judge (costs money, flexible).** A cheap model evaluates: "Does this response answer the question about emails from Alice? Does it include the meeting email?" This handles semantic assertions that substring matching can't express.
+| You just... | Write a... | Because... |
+|------------|-----------|-----------|
+| Wrote a new function | Unit test | You're the author, verify your logic works |
+| Added an API endpoint | Contract test | Consumers need to trust the endpoint's promises |
+| Added a new LLM provider | Conformance test | It must honor the same protocol as every other provider |
+| Wired two subsystems together | Integration test | The boundary between them needs verification |
+| Added a new user-facing capability | Spec test | The user's perspective is the only one that can verify it |
+| Fixed a bug | Test at the lowest level that reproduces it | Don't use a spec test for what a unit test can catch |
 
-```go
-AssertJudge(t, fx, response, []string{
-    "mentions at least one email from alice",
-    "includes the subject line about the meeting",
-})
-```
+### Naming tests
 
-We use Layer 1+2 by default and add Layer 3 when the assertion is genuinely semantic.
+Test names describe behavior from the test's perspective:
+- Unit: `TestRetry_429Retries`, `TestExtractContent_ImageMessage`
+- Contract: `TestAPI_MemoryRejectsWithoutAuth`
+- Conformance: `TestProvider_ToolUseRoundtrip`
+- Integration: `TestSession_MemoryInjectedIntoPrompt`
+- Spec: `TestSpec_FindEmailsBySender`
 
-### Current specs
+### Graceful skipping
 
-| Spec | What it proves |
-|------|---------------|
-| `TestSpec_FindEmailsBySender` | Agent discovers email-read skill, queries database, filters by sender |
-| `TestSpec_SummarizeCommunicationsAcrossSources` | Agent autonomously queries both email and WhatsApp, synthesizes results |
-| `TestSpec_RecallMemoryAndCorrelateEmails` | Agent combines personal memories with email search |
+Tests that need external resources (LLM API keys, sqlite3 binary, Docker) skip with `t.Skip()`. This means `go test ./...` always passes on a fresh checkout — unit tests run, everything else skips gracefully. Helpers like `testutil.RequireGeminiKey(t)` standardize this.
 
-## Graceful skipping
+### Conventions
 
-Tests that need external resources (LLM API keys, sqlite3 binary, Docker) skip with `t.Skip()` rather than fail. This means:
-
-- `go test ./...` always passes on a fresh checkout (unit tests run, integration tests skip)
-- CI with credentials set runs the full suite
-- A developer without a Gemini key can still run and trust all non-LLM tests
-
-Helper functions like `testutil.RequireGeminiKey(t)` standardize this pattern.
-
-## CI configuration
-
-`.github/workflows/ci.yml` runs:
-- `go test ./...` on Ubuntu, macOS, and Windows
-- Cross-compilation for linux/amd64, linux/arm64, linux/riscv64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64
-
-## When to write which test
-
-| Situation | Test level |
-|-----------|-----------|
-| New function or method | Unit test |
-| New API endpoint | Add to server contract suite |
-| New LLM provider | Provider conformance tests |
-| New messaging channel | Session integration test |
-| New user-facing capability ("the agent can now do X") | Spec test |
-| Bug fix | Test at the lowest level that reproduces the bug |
+- Standard `testing` package only. No test frameworks.
+- Mocks live in the test file that uses them.
+- Database tests use in-memory SQLite or `t.TempDir()` — no shared state.
+- All test assertions are explicit `if` checks with `t.Fatalf`. The failure message says what was expected and what was got.


### PR DESCRIPTION
## Summary

- Replaces `docs/spectest-design.md` with `docs/testing-strategy.md` covering the full testing approach
- Each test level is defined by its **perspective** and the **question it answers**, not by vague labels
- Five perspectives: author (unit), consumer (contract), protocol (conformance), boundary (integration), user (spec)
- Includes concrete examples from the codebase, assertion strategies, naming conventions, and guidance on when to write which type of test

## Test plan

- [x] Read the document and verify it accurately reflects the project's testing philosophy