### PR TITLE
Fix race condition in ScopeWaiter consent flow

### DIFF
--- a/agent/tools/gws_execute.go
+++ b/agent/tools/gws_execute.go
@@ -210,6 +210,9 @@ func (g *GWSExecuteTool) requestConsent(ctx context.Context, scopes []string) er
 	if err != nil {
 		return fmt.Errorf("generate auth URL: %w", err)
 	}
+	// Register before notifying so Signal can't race ahead of Await.
+	g.scopeWaiter.Register(state, scopes, g.account)
+
 	if err := g.interactor.Notify("I need additional Google access to complete this request."); err != nil {
 		return fmt.Errorf("notify: %w", err)
 	}
@@ -217,7 +220,7 @@ func (g *GWSExecuteTool) requestConsent(ctx context.Context, scopes []string) er
 		return fmt.Errorf("notify link: %w", err)
 	}
 
-	if err := g.scopeWaiter.Wait(state, g.authTimeout, scopes, g.account); err != nil {
+	if err := g.scopeWaiter.Await(state, g.authTimeout); err != nil {
 		return fmt.Errorf("auth: %w", err)
 	}
 

--- a/oauth/google/waiter.go
+++ b/oauth/google/waiter.go
@@ -26,17 +26,28 @@ func NewScopeWaiter() *ScopeWaiter {
 	return &ScopeWaiter{pending: make(map[string]*pendingAuth)}
 }
 
-// Wait blocks until Signal is called for the given state or the timeout expires.
-// The scopes and account are stored so the callback can retrieve them via Lookup.
-func (w *ScopeWaiter) Wait(state string, timeout time.Duration, scopes []string, account string) error {
+// Register adds a pending auth entry so that Signal can resolve it
+// even before Await is called — eliminating the race where Signal
+// fires between NotifyLink and Await.
+func (w *ScopeWaiter) Register(state string, scopes []string, account string) {
 	w.mu.Lock()
-	p := &pendingAuth{
+	w.pending[state] = &pendingAuth{
 		ch:      make(chan error, 1),
 		scopes:  scopes,
 		account: account,
 	}
-	w.pending[state] = p
 	w.mu.Unlock()
+}
+
+// Await blocks until Signal is called for a previously registered state
+// or the timeout expires.
+func (w *ScopeWaiter) Await(state string, timeout time.Duration) error {
+	w.mu.Lock()
+	p, ok := w.pending[state]
+	w.mu.Unlock()
+	if !ok {
+		return errors.New("state not registered")
+	}
 
 	defer func() {
 		w.mu.Lock()
@@ -50,6 +61,13 @@ func (w *ScopeWaiter) Wait(state string, timeout time.Duration, scopes []string,
 	case <-time.After(timeout):
 		return ErrAuthTimeout
 	}
+}
+
+// Wait registers a state and blocks until Signal is called or timeout.
+// For race-free usage prefer Register + Await.
+func (w *ScopeWaiter) Wait(state string, timeout time.Duration, scopes []string, account string) error {
+	w.Register(state, scopes, account)
+	return w.Await(state, timeout)
 }
 
 // Lookup returns the scopes and account associated with a pending state.


### PR DESCRIPTION
## Summary
- Fixed a race condition in `ScopeWaiter` where `Signal` could fire before `Wait` registered the pending state, causing the consent flow to hang
- Split `Wait` into `Register` + `Await` so the state is registered before the auth link is sent via `NotifyLink`
- This was causing flaky `TestGWSExecute_MissingScopeSignaled` failures in CI

## Test plan
- [x] `TestGWSExecute_MissingScopeSignaled` passes 10/10 with `-count=10`
- [x] All `TestScopeWaiter_*` tests pass
- [x] Full `agent/tools` test suite passes
- [x] `go build ./...` passes