### PR TITLE
Apply gofmt formatting to agent/tools

### DIFF
--- a/agent/tools/delegate_task_test.go
+++ b/agent/tools/delegate_task_test.go
@@ -319,7 +319,9 @@ func TestDelegateTask_AsyncCompleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	var resp struct{ TaskID string `json:"task_id"` }
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
 	json.Unmarshal([]byte(result), &resp)
 
 	// Wait for goroutine to start, then release.
@@ -374,7 +376,9 @@ func TestDelegateTask_AsyncFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	var resp struct{ TaskID string `json:"task_id"` }
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
 	json.Unmarshal([]byte(result), &resp)
 
 	<-runner.called
@@ -572,7 +576,9 @@ func TestDelegateTask_AsyncStreamingCompleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	var resp struct{ TaskID string `json:"task_id"` }
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
 	json.Unmarshal([]byte(result), &resp)
 
 	// Wait for completion notification.
@@ -627,7 +633,9 @@ func TestDelegateTask_AsyncStreamingFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	var resp struct{ TaskID string `json:"task_id"` }
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
 	json.Unmarshal([]byte(result), &resp)
 
 	select {
@@ -921,7 +929,9 @@ func TestDelegateTask_AsyncWritesResultFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	var resp struct{ TaskID string `json:"task_id"` }
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
 	json.Unmarshal([]byte(result), &resp)
 
 	<-runner.called

--- a/agent/tools/file.go
+++ b/agent/tools/file.go
@@ -41,8 +41,10 @@ func (f *FileReadTool) Execute(_ context.Context, input json.RawMessage) (string
 // FileWriteTool writes content to a file.
 type FileWriteTool struct{}
 
-func (f *FileWriteTool) Name() string        { return "file_write" }
-func (f *FileWriteTool) Description() string { return "Write content to a file (creates or overwrites)" }
+func (f *FileWriteTool) Name() string { return "file_write" }
+func (f *FileWriteTool) Description() string {
+	return "Write content to a file (creates or overwrites)"
+}
 func (f *FileWriteTool) InputSchema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",

--- a/agent/tools/gws_execute_test.go
+++ b/agent/tools/gws_execute_test.go
@@ -378,8 +378,8 @@ func TestGWSExecute_StructuredParams(t *testing.T) {
 	input, _ := json.Marshal(map[string]any{
 		"command": "drive files list",
 		"params": map[string]any{
-			"q":       "mimeType='application/vnd.google-apps.document'",
-			"orderBy": "modifiedTime desc",
+			"q":        "mimeType='application/vnd.google-apps.document'",
+			"orderBy":  "modifiedTime desc",
 			"pageSize": 5,
 		},
 	})

--- a/agent/tools/interactor.go
+++ b/agent/tools/interactor.go
@@ -12,4 +12,3 @@ type Interactor interface {
 	// RequestApproval asks the user to approve an action. Blocks until the user responds.
 	RequestApproval(description string) (approved bool, err error)
 }
-

--- a/agent/tools/load_skills.go
+++ b/agent/tools/load_skills.go
@@ -14,8 +14,10 @@ import (
 // LoadSkillsTool reads full SKILL.md content for named skills.
 type LoadSkillsTool struct{}
 
-func (l *LoadSkillsTool) Name() string        { return "load_skills" }
-func (l *LoadSkillsTool) Description() string { return "Load full skill instructions for the specified skills" }
+func (l *LoadSkillsTool) Name() string { return "load_skills" }
+func (l *LoadSkillsTool) Description() string {
+	return "Load full skill instructions for the specified skills"
+}
 func (l *LoadSkillsTool) InputSchema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",

--- a/agent/tools/risk.go
+++ b/agent/tools/risk.go
@@ -8,4 +8,3 @@ const (
 	RiskMedium                  // standard approval (current behavior)
 	RiskHigh                    // enhanced approval with full preview
 )
-

--- a/agent/tools/sanitize_test.go
+++ b/agent/tools/sanitize_test.go
@@ -131,9 +131,9 @@ func TestNormalizeHomoglyphs(t *testing.T) {
 		want  string
 	}{
 		{"hello", "hello"},
-		{"\u0430bc", "abc"},                       // Cyrillic a → a
-		{"te\u200bst", "test"},                     // zero-width space removed
-		{"\u0456gnore", "ignore"},                  // Cyrillic і → i
+		{"\u0430bc", "abc"},       // Cyrillic a → a
+		{"te\u200bst", "test"},    // zero-width space removed
+		{"\u0456gnore", "ignore"}, // Cyrillic і → i
 	}
 	for _, tc := range cases {
 		if got := normalizeHomoglyphs(tc.input); got != tc.want {

--- a/agent/tools/subagent_test.go
+++ b/agent/tools/subagent_test.go
@@ -38,10 +38,12 @@ type stubTool struct {
 	output string
 }
 
-func (s *stubTool) Name() string                                                          { return s.name }
-func (s *stubTool) Description() string                                                   { return "stub" }
-func (s *stubTool) InputSchema() json.RawMessage                                          { return json.RawMessage(`{"type":"object"}`) }
-func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) { return s.output, nil }
+func (s *stubTool) Name() string                 { return s.name }
+func (s *stubTool) Description() string          { return "stub" }
+func (s *stubTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return s.output, nil
+}
 
 func newSubagentTool(mp *mockProvider) *tools.SubagentTool {
 	return tools.NewSubagentTool(tools.SubagentConfig{

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -194,10 +194,12 @@ type stubTool struct {
 	output string
 }
 
-func (s *stubTool) Name() string                                                     { return s.name }
-func (s *stubTool) Description() string                                              { return "stub" }
-func (s *stubTool) InputSchema() json.RawMessage                                     { return json.RawMessage(`{"type":"object"}`) }
-func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) { return s.output, nil }
+func (s *stubTool) Name() string                 { return s.name }
+func (s *stubTool) Description() string          { return "stub" }
+func (s *stubTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return s.output, nil
+}
 
 func TestBashTool_TruncatesLargeOutput(t *testing.T) {
 	b := NewBashTool(10 * time.Second)

--- a/agent/tools/truncate.go
+++ b/agent/tools/truncate.go
@@ -7,13 +7,13 @@ import (
 
 // Standard truncation limits shared across tools.
 const (
-	MaxOutputBytes     = 50 * 1024 // 50KB byte cap for all tools.
-	MaxLinesBash       = 2000      // bash: tail-truncate (errors at bottom).
-	MaxLinesFileRead   = 2000      // file_read: head-truncate.
-	MaxLinesWebFetch   = 1000      // web_fetch: head-truncate.
-	MaxLinesSlack      = 1000      // slack_*: head-truncate.
-	MaxLinesWebSearch  = 500       // web_search: head-truncate.
-	MaxLinesHeadTail   = 500       // gws/subagent/delegate: head+tail.
+	MaxOutputBytes    = 50 * 1024 // 50KB byte cap for all tools.
+	MaxLinesBash      = 2000      // bash: tail-truncate (errors at bottom).
+	MaxLinesFileRead  = 2000      // file_read: head-truncate.
+	MaxLinesWebFetch  = 1000      // web_fetch: head-truncate.
+	MaxLinesSlack     = 1000      // slack_*: head-truncate.
+	MaxLinesWebSearch = 500       // web_search: head-truncate.
+	MaxLinesHeadTail  = 500       // gws/subagent/delegate: head+tail.
 )
 
 // TruncateHead keeps the first maxLines lines (for file_read, web results).


### PR DESCRIPTION
## Summary
- Formatting fixes (gofmt) across 10 files in `agent/tools/`
- Removed trailing newlines, aligned struct fields, wrapped long single-line methods

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./agent/tools/` passes