### PR TITLE
fix(tools): use production timeout for agent integration tests

### DIFF
--- a/agent/tools/agent_runner_test.go
+++ b/agent/tools/agent_runner_test.go
@@ -200,7 +200,7 @@ func TestAgentRunner_RealClaude(t *testing.T) {
 		}
 	}
 	r := NewAgentRunner(info)
-	out, err := r.Run(context.Background(), "Say hello in exactly one word.", 30*time.Second)
+	out, err := r.Run(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestAgentRunner_RealGemini(t *testing.T) {
 		}
 	}
 	r := NewAgentRunner(info)
-	out, err := r.Run(context.Background(), "Say hello in exactly one word.", 30*time.Second)
+	out, err := r.Run(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "Permission") || strings.Contains(err.Error(), "denied") || strings.Contains(err.Error(), "auth") {
 			t.Skipf("gemini auth not configured: %v", err)
@@ -247,7 +247,7 @@ func TestAgentRunner_RealCodex(t *testing.T) {
 		}
 	}
 	r := NewAgentRunner(info)
-	out, err := r.Run(context.Background(), "Say hello in exactly one word.", 30*time.Second)
+	out, err := r.Run(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "auth") || strings.Contains(err.Error(), "API key") || strings.Contains(err.Error(), "login") {
 			t.Skipf("codex auth not configured: %v", err)

--- a/agent/tools/agent_stream_test.go
+++ b/agent/tools/agent_stream_test.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestParseStreamLine_Text(t *testing.T) {
@@ -218,7 +217,7 @@ func TestStreamRunner_RealClaude(t *testing.T) {
 	}
 	r := NewStreamRunner(info)
 	var eventCount int
-	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", 30*time.Second, func(evt StreamEvent) {
+	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout, func(evt StreamEvent) {
 		eventCount++
 	})
 	if err != nil {
@@ -246,7 +245,7 @@ func TestStreamRunner_RealGemini(t *testing.T) {
 	}
 	r := NewStreamRunner(info)
 	var eventCount int
-	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", 30*time.Second, func(evt StreamEvent) {
+	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout, func(evt StreamEvent) {
 		eventCount++
 	})
 	if err != nil {
@@ -274,7 +273,7 @@ func TestStreamRunner_RealCodex(t *testing.T) {
 	}
 	r := NewStreamRunner(info)
 	var eventCount int
-	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", 30*time.Second, func(evt StreamEvent) {
+	out, err := r.RunStream(context.Background(), "Say hello in exactly one word.", defaultDelegateTimeout, func(evt StreamEvent) {
 		eventCount++
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Agent runner and stream integration tests (TestAgentRunner_RealGemini, TestStreamRunner_RealGemini, etc.) used a hardcoded 30s timeout
- Production code uses `defaultDelegateTimeout` (5 minutes) — these are background delegation tasks, not latency-sensitive operations
- Gemini CLI cold-starts take ~31s, causing flaky test failures when the 30s timeout hits during initialization
- When running with the full test suite, CPU contention makes this worse

Changed all 6 real agent tests to use `defaultDelegateTimeout` instead of `30*time.Second`. The Go test framework's own timeout (`-timeout` flag, default 10min) is the real safety net against hangs.

## Test plan

- [x] `TestAgentRunner_RealGemini` passes (12s)
- [x] `TestStreamRunner_RealGemini` passes (10s)
- [x] `go build ./agent/tools/...` clean