### PR TITLE
Fix: remove [skip ci] that blocks release workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,6 +35,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "chore(release): ${VERSION} [skip ci]"
+          git commit -m "chore(release): ${VERSION}"
           git tag "${VERSION}"
           git push origin master --tags

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -32,6 +32,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "chore(release): ${VERSION} [skip ci]"
+          git commit -m "chore(release): ${VERSION}"
           git tag "${VERSION}"
           git push origin master --tags


### PR DESCRIPTION
## Summary

- The `[skip ci]` in the changelog commit message was also blocking the tag-triggered `release.yml` (GoReleaser) from running
- The changelog workflow already has an `if` guard (`!startsWith(... 'chore(release)')`) to prevent infinite loops, so `[skip ci]` is unnecessary
- Also fixes `release-minor.yml` with the same change

## Test plan

- [ ] Merge and verify the changelog workflow creates a tag that triggers `release.yml`
- [ ] Can also manually trigger by deleting the `v0.1.0` tag and re-running the changelog workflow