### PR TITLE
fix(ci): handle existing tags in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,19 +27,18 @@ jobs:
       - name: Commit and tag
         if: steps.cliff.outputs.version != ''
         run: |
+          VERSION="${{ steps.cliff.outputs.version }}"
+          if git rev-parse "${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists, no new release needed"
+            exit 0
+          fi
           if git diff --quiet CHANGELOG.md; then
             echo "No changelog changes"
             exit 0
           fi
-          VERSION="${{ steps.cliff.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "chore(release): ${VERSION}"
-          if git rev-parse "${VERSION}" >/dev/null 2>&1; then
-            echo "Tag ${VERSION} already exists, skipping tag creation"
-            git push origin master
-          else
-            git tag "${VERSION}"
-            git push origin master --tags
-          fi
+          git tag "${VERSION}"
+          git push origin master --tags


### PR DESCRIPTION
## Summary

- Fix changelog CI failure where `git tag` fails because the version tag already exists
- When a tag already exists, skip tag creation and just push the changelog commit

Fixes the failure in run #23533803964 where `git tag 'v0.5.0'` failed because v0.5.0 was already tagged.

## Test plan

- [ ] CI passes on this PR
- [ ] Merge and verify the changelog workflow succeeds on master