### PR TITLE
feat(slack): thread debugging toolkit — thread, media download, reply

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,11 @@
   - Keep commits small: aim for under 20 lines changed per commit.
   - Don't batch multiple unrelated changes into one commit.
   - Commit early and often — a working 5-line change is better than a pending 200-line change.
+
+## Pull Request Rules
+
+  - PR descriptions are plain text. No markdown, no headings, no bullets, no bold, no code blocks, no emoji, no tables.
+  - A few lines, that's it. Don't write an essay.
+  - Super casual, like telling a teammate over chat. Lowercase is fine.
+  - Don't polish it. A few typos and loose grammar are fine and preferred over something that reads like a template.
+  - Keep the facts right even though the tone is casual. Casual is about the voice, not about being vague or wrong.

--- a/agent/tools/prompt.go
+++ b/agent/tools/prompt.go
@@ -121,6 +121,9 @@ Do NOT use bash or skills for web search/fetch — use these tools directly.
 		b.WriteString(`
 ## Slack
 Use the slack_search, slack_read_channel, and slack_read_thread tools for reading Slack content.
+slack_read_thread takes a message permalink and returns the whole thread with names resolved.
+Use slack_media_download to save a message's attachments, then read the file — screenshots usually
+hold the actual error message.
 Use slack_send, slack_edit, and slack_react for write operations (these require user approval).
 Channel references accept: #name, C-ID, or Slack archive URL. User references accept: @handle, U-ID, or email.
 `)

--- a/agent/tools/sanitize.go
+++ b/agent/tools/sanitize.go
@@ -125,17 +125,18 @@ func normalizeHomoglyphs(s string) string {
 // untrustedOutputTools lists tools whose output should be treated as
 // untrusted content (may contain prompt injection attempts).
 var untrustedOutputTools = map[string]bool{
-	"bash":               true,
-	"file_read":          true,
-	"dir_explore":        true,
-	"content_search":     true,
-	"sandbox_exec":       true,
-	"gws_execute":        true,
-	"slack_read_channel": true,
-	"slack_read_thread":  true,
-	"slack_search":       true,
-	"web_search":         true,
-	"web_fetch":          true,
+	"bash":                 true,
+	"file_read":            true,
+	"dir_explore":          true,
+	"content_search":       true,
+	"sandbox_exec":         true,
+	"gws_execute":          true,
+	"slack_read_channel":   true,
+	"slack_read_thread":    true,
+	"slack_search":         true,
+	"slack_media_download": true,
+	"web_search":           true,
+	"web_fetch":            true,
 }
 
 // IsUntrustedTool returns whether a tool's output should be wrapped

--- a/agent/tools/slack_deps.go
+++ b/agent/tools/slack_deps.go
@@ -9,6 +9,9 @@ type SlackToolDeps struct {
 	Resolver      *slack.Resolver
 	Interactor    Interactor
 	ApprovalRules *ApprovalRuleSet
+	Workspace     string // enables ID -> name resolution
+	ScratchDir    string // where downloaded media is written
+	UserCache     *slack.UserCache
 }
 
 // SlackResolver returns the shared Resolver, creating one if needed.
@@ -17,6 +20,18 @@ func (d SlackToolDeps) SlackResolver() *slack.Resolver {
 		return d.Resolver
 	}
 	return slack.NewResolver(d.Client)
+}
+
+// SlackUserCache returns the name cache, or nil when no workspace is
+// configured — callers treat nil as "skip name resolution".
+func (d SlackToolDeps) SlackUserCache() *slack.UserCache {
+	if d.UserCache != nil {
+		return d.UserCache
+	}
+	if d.Workspace == "" {
+		return nil
+	}
+	return slack.NewUserCache(d.Workspace, d.Client)
 }
 
 // truncateUTF8 truncates s to at most maxRunes runes, appending "..." if truncated.

--- a/agent/tools/slack_media_download.go
+++ b/agent/tools/slack_media_download.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/73ai/openbotkit/source/slack"
+)
+
+type SlackMediaDownloadTool struct {
+	deps SlackToolDeps
+}
+
+func NewSlackMediaDownloadTool(deps SlackToolDeps) *SlackMediaDownloadTool {
+	return &SlackMediaDownloadTool{deps: deps}
+}
+
+func (t *SlackMediaDownloadTool) Name() string { return "slack_media_download" }
+func (t *SlackMediaDownloadTool) Description() string {
+	return "Download a file attached to a Slack message and save it locally. Takes a url_private from a message's files[], or a /files/… permalink. Returns the saved path, which you can then read — screenshots often hold the actual error message."
+}
+func (t *SlackMediaDownloadTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"url": {
+				"type": "string",
+				"description": "The file's url_private, or its /files/… permalink"
+			},
+			"filename": {
+				"type": "string",
+				"description": "Optional name for the saved file; defaults to the name in the URL"
+			}
+		},
+		"required": ["url"]
+	}`)
+}
+
+type slackMediaDownloadInput struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
+}
+
+func (t *SlackMediaDownloadTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var in slackMediaDownloadInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return "", fmt.Errorf("parse input: %w", err)
+	}
+	if in.URL == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	if t.deps.ScratchDir == "" {
+		slog.Warn("slack_media_download: no scratch dir configured")
+		return "", fmt.Errorf("no scratch directory configured, cannot save the file")
+	}
+
+	downloadURL, err := slack.ResolveFileURL(ctx, t.deps.Client, in.URL)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(t.deps.ScratchDir, 0700); err != nil {
+		return "", fmt.Errorf("create scratch dir: %w", err)
+	}
+	path := filepath.Join(t.deps.ScratchDir, mediaFilename(in.Filename, downloadURL))
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return "", fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	if err := t.deps.Client.DownloadFile(ctx, downloadURL, f); err != nil {
+		return "", err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Sprintf("Saved to %s", path), nil
+	}
+	return fmt.Sprintf("Saved to %s (%d bytes). Use file_read to view it.", path, info.Size()), nil
+}
+
+var unsafeFilenameRe = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+// mediaFilename picks a safe base name, preferring the caller's, then the last
+// path segment of the URL, then a random name.
+func mediaFilename(requested, downloadURL string) string {
+	name := requested
+	if name == "" {
+		trimmed, _, _ := strings.Cut(downloadURL, "?")
+		name = filepath.Base(trimmed)
+	}
+	name = unsafeFilenameRe.ReplaceAllString(filepath.Base(name), "_")
+	name = strings.TrimLeft(name, ".")
+	if name == "" || name == "_" {
+		name = "slack_file_" + rand.Text()
+	}
+	return "slack_" + name
+}

--- a/agent/tools/slack_media_download_test.go
+++ b/agent/tools/slack_media_download_test.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/73ai/openbotkit/source/slack"
+)
+
+func TestSlackMediaDownloadTool_Execute(t *testing.T) {
+	dir := t.TempDir()
+	api := &mockSlackAPI{downloadBody: "\x89PNG\r\n\x1a\nfake"}
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: api, ScratchDir: dir})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL: "https://files.slack.com/files-pri/T1-F1/shot.png",
+	})
+	result, err := tool.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "slack_shot.png")
+	if !strings.Contains(result, path) {
+		t.Errorf("result = %q, want the saved path", result)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != api.downloadBody {
+		t.Errorf("file contents = %q", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("mode = %v, want 0600", perm)
+	}
+}
+
+func TestSlackMediaDownloadTool_ResolvesPermalink(t *testing.T) {
+	dir := t.TempDir()
+	api := &mockSlackAPI{
+		downloadBody: "jpegdata",
+		fileInfo: &slack.File{
+			ID:         "F0BLMEDEJCS",
+			URLPrivate: "https://files.slack.com/files-pri/T1-F0BLMEDEJCS/file.jpg",
+		},
+	}
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: api, ScratchDir: dir})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL: "https://acme.slack.com/files/U02CMP7DXU1/F0BLMEDEJCS/file.jpg",
+	})
+	if _, err := tool.Execute(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	if api.downloadedURL != api.fileInfo.URLPrivate {
+		t.Errorf("downloaded %q, want the url_private", api.downloadedURL)
+	}
+}
+
+func TestSlackMediaDownloadTool_CustomFilename(t *testing.T) {
+	dir := t.TempDir()
+	api := &mockSlackAPI{downloadBody: "data"}
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: api, ScratchDir: dir})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL:      "https://files.slack.com/files-pri/T1-F1/shot.png",
+		Filename: "customer_error.png",
+	})
+	if _, err := tool.Execute(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "slack_customer_error.png")); err != nil {
+		t.Errorf("expected the custom name: %v", err)
+	}
+}
+
+// A filename from Slack must not be able to escape the scratch directory.
+func TestSlackMediaDownloadTool_FilenameStaysInScratch(t *testing.T) {
+	dir := t.TempDir()
+	api := &mockSlackAPI{downloadBody: "data"}
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: api, ScratchDir: dir})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL:      "https://files.slack.com/files-pri/T1-F1/shot.png",
+		Filename: "../../escaped.png",
+	})
+	result, err := tool.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(result, "..") {
+		t.Errorf("path escaped the scratch dir: %q", result)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 file in scratch, got %d", len(entries))
+	}
+	if strings.Contains(entries[0].Name(), "/") || strings.HasPrefix(entries[0].Name(), ".") {
+		t.Errorf("unsafe name %q", entries[0].Name())
+	}
+}
+
+func TestSlackMediaDownloadTool_MissingParams(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}, ScratchDir: t.TempDir()})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{})
+	if _, err := tool.Execute(context.Background(), input); err == nil {
+		t.Fatal("expected error for missing url")
+	}
+}
+
+func TestSlackMediaDownloadTool_NoScratchDir(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL: "https://files.slack.com/files-pri/T1-F1/shot.png",
+	})
+	_, err := tool.Execute(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error when no scratch dir is configured")
+	}
+	if !strings.Contains(err.Error(), "scratch") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestSlackMediaDownloadTool_Name(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}})
+	if tool.Name() != "slack_media_download" {
+		t.Errorf("Name() = %q", tool.Name())
+	}
+}
+
+func TestSlackMediaDownloadTool_Metadata(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}})
+	if tool.Description() == "" {
+		t.Error("empty description")
+	}
+	if !json.Valid(tool.InputSchema()) {
+		t.Error("invalid schema")
+	}
+}
+
+func TestSlackMediaDownloadTool_InvalidJSON(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}})
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{bad`)); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestSlackMediaDownloadTool_ResolveError(t *testing.T) {
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: &mockSlackAPI{}, ScratchDir: t.TempDir()})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{URL: "F0BLMEDEJCS"})
+	if _, err := tool.Execute(context.Background(), input); err == nil {
+		t.Fatal("expected error for a bare file ID")
+	}
+}
+
+func TestSlackMediaDownloadTool_DownloadError(t *testing.T) {
+	dir := t.TempDir()
+	api := &mockSlackAPI{downloadErr: errors.New("got an HTML page instead of the file")}
+	tool := NewSlackMediaDownloadTool(SlackToolDeps{Client: api, ScratchDir: dir})
+
+	input, _ := json.Marshal(slackMediaDownloadInput{
+		URL: "https://files.slack.com/files-pri/T1-F1/shot.png",
+	})
+	_, err := tool.Execute(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HTML page") {
+		t.Errorf("error = %q", err)
+	}
+}

--- a/agent/tools/slack_read_thread.go
+++ b/agent/tools/slack_read_thread.go
@@ -22,28 +22,32 @@ func NewSlackReadThreadTool(deps SlackToolDeps) *SlackReadThreadTool {
 
 func (t *SlackReadThreadTool) Name() string { return "slack_read_thread" }
 func (t *SlackReadThreadTool) Description() string {
-	return "Read replies in a Slack thread"
+	return "Read a complete Slack thread, with user IDs resolved to names. Accepts a message permalink, or a channel plus thread_ts. Any message in the thread works: a link to a reply returns the whole thread."
 }
 func (t *SlackReadThreadTool) InputSchema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
+			"permalink": {
+				"type": "string",
+				"description": "Slack message permalink, e.g. https://acme.slack.com/archives/C01ABC/p1785334150236249"
+			},
 			"channel": {
 				"type": "string",
-				"description": "Channel name, ID, or URL"
+				"description": "Channel name, ID, or URL (use with thread_ts)"
 			},
 			"thread_ts": {
 				"type": "string",
-				"description": "Timestamp of the parent message"
+				"description": "Timestamp of any message in the thread, dotted (1785334150.236249) or p-form (p1785334150236249)"
 			}
-		},
-		"required": ["channel", "thread_ts"]
+		}
 	}`)
 }
 
 type slackReadThreadInput struct {
-	Channel  string `json:"channel"`
-	ThreadTS string `json:"thread_ts"`
+	Permalink string `json:"permalink"`
+	Channel   string `json:"channel"`
+	ThreadTS  string `json:"thread_ts"`
 }
 
 func (t *SlackReadThreadTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
@@ -51,25 +55,48 @@ func (t *SlackReadThreadTool) Execute(ctx context.Context, input json.RawMessage
 	if err := json.Unmarshal(input, &in); err != nil {
 		return "", fmt.Errorf("parse input: %w", err)
 	}
-	if in.Channel == "" || in.ThreadTS == "" {
-		return "", fmt.Errorf("channel and thread_ts are required")
-	}
 
-	channelID, err := t.resolver.ResolveChannel(ctx, in.Channel)
+	channelID, ts, err := t.resolve(ctx, in)
 	if err != nil {
 		return "", err
 	}
 
-	msgs, err := t.deps.Client.ConversationsReplies(ctx, channelID, in.ThreadTS, slack.HistoryOptions{})
+	thread, err := slack.FetchThread(ctx, t.deps.Client, t.deps.SlackUserCache(), channelID, ts)
 	if err != nil {
-		return "", fmt.Errorf("fetch replies: %w", err)
+		return "", err
 	}
 
-	out, err := compactMarshal(msgs)
+	out, err := compactMarshal(thread)
 	if err != nil {
 		return "", err
 	}
 	out = TruncateHead(out, MaxLinesSlack)
 	out = TruncateBytes(out, MaxOutputBytes)
 	return out, nil
+}
+
+func (t *SlackReadThreadTool) resolve(ctx context.Context, in slackReadThreadInput) (channelID, ts string, err error) {
+	if in.Permalink != "" {
+		ref, err := slack.ParsePermalink(in.Permalink)
+		if err != nil {
+			return "", "", err
+		}
+		ts, err := ref.RootTS()
+		if err != nil {
+			return "", "", err
+		}
+		return ref.ChannelID, ts, nil
+	}
+
+	if in.Channel == "" || in.ThreadTS == "" {
+		return "", "", fmt.Errorf("provide permalink, or both channel and thread_ts")
+	}
+	channelID, err = t.resolver.ResolveChannel(ctx, in.Channel)
+	if err != nil {
+		return "", "", err
+	}
+	if ts, err = slack.MessageIDToTS(in.ThreadTS); err != nil {
+		return "", "", err
+	}
+	return channelID, ts, nil
 }

--- a/agent/tools/slack_read_thread_test.go
+++ b/agent/tools/slack_read_thread_test.go
@@ -12,20 +12,98 @@ import (
 func TestSlackReadThreadTool_Execute(t *testing.T) {
 	api := &mockSlackAPI{
 		repliesResult: []slack.Message{
-			{TS: "111", Text: "parent message"},
-			{TS: "222", Text: "reply 1", ThreadTS: "111"},
+			{TS: "1785334150.236249", Text: "parent message"},
+			{TS: "1785334200.111111", Text: "reply 1", ThreadTS: "1785334150.236249"},
 		},
 		channels: []slack.Channel{{ID: "C123", Name: "general"}},
 	}
 	tool := NewSlackReadThreadTool(SlackToolDeps{Client: api})
 
-	input, _ := json.Marshal(slackReadThreadInput{Channel: "C123", ThreadTS: "111"})
+	input, _ := json.Marshal(slackReadThreadInput{Channel: "C123", ThreadTS: "1785334150.236249"})
 	result, err := tool.Execute(context.Background(), input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(result, "reply 1") {
 		t.Errorf("result = %q", result)
+	}
+	if !strings.Contains(result, "p1785334150236249") {
+		t.Errorf("expected message_id in output: %q", result)
+	}
+}
+
+func TestSlackReadThreadTool_Permalink(t *testing.T) {
+	api := &mockSlackAPI{
+		repliesResult: []slack.Message{
+			{TS: "1785334150.236249", Text: "parent message"},
+			{TS: "1785334200.111111", Text: "reply 1", ThreadTS: "1785334150.236249"},
+		},
+	}
+	tool := NewSlackReadThreadTool(SlackToolDeps{Client: api})
+
+	input, _ := json.Marshal(slackReadThreadInput{
+		Permalink: "https://acme.slack.com/archives/C01Q9G9CD6X/p1785334150236249",
+	})
+	result, err := tool.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "C01Q9G9CD6X") {
+		t.Errorf("result = %q", result)
+	}
+	if len(api.repliesTS) == 0 || api.repliesTS[0] != "1785334150.236249" {
+		t.Errorf("requested ts = %v", api.repliesTS)
+	}
+}
+
+// A permalink to a reply carries thread_ts; the whole thread comes back.
+func TestSlackReadThreadTool_PermalinkToReply(t *testing.T) {
+	api := &mockSlackAPI{
+		repliesResult: []slack.Message{
+			{TS: "1785319311.419309", Text: "the root"},
+			{TS: "1785319451.036269", Text: "a reply", ThreadTS: "1785319311.419309"},
+		},
+	}
+	tool := NewSlackReadThreadTool(SlackToolDeps{Client: api})
+
+	input, _ := json.Marshal(slackReadThreadInput{
+		Permalink: "https://acme.slack.com/archives/C094FL95GDV/p1785319451036269?thread_ts=1785319311.419309",
+	})
+	result, err := tool.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(api.repliesTS) == 0 || api.repliesTS[0] != "1785319311.419309" {
+		t.Errorf("should fetch the root, requested %v", api.repliesTS)
+	}
+	if !strings.Contains(result, "the root") || !strings.Contains(result, "a reply") {
+		t.Errorf("result = %q", result)
+	}
+}
+
+func TestSlackReadThreadTool_ResolvesNames(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &mockSlackAPI{
+		repliesResult: []slack.Message{
+			{TS: "1785334150.236249", User: "U1", Text: "hello <@U2>"},
+		},
+		userInfo: map[string]*slack.User{
+			"U1": {ID: "U1", Profile: &slack.UserProfile{DisplayName: "rahul.support"}},
+			"U2": {ID: "U2", Name: "priya"},
+		},
+	}
+	tool := NewSlackReadThreadTool(SlackToolDeps{Client: api, Workspace: "acme"})
+
+	input, _ := json.Marshal(slackReadThreadInput{Channel: "C123", ThreadTS: "p1785334150236249"})
+	result, err := tool.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "rahul.support") {
+		t.Errorf("author name missing: %q", result)
+	}
+	if !strings.Contains(result, "priya") {
+		t.Errorf("mentioned user missing from users map: %q", result)
 	}
 }
 
@@ -36,6 +114,19 @@ func TestSlackReadThreadTool_MissingParams(t *testing.T) {
 	_, err := tool.Execute(context.Background(), input)
 	if err == nil {
 		t.Fatal("expected error for missing thread_ts")
+	}
+
+	input, _ = json.Marshal(slackReadThreadInput{})
+	if _, err := tool.Execute(context.Background(), input); err == nil {
+		t.Fatal("expected error when nothing is provided")
+	}
+}
+
+func TestSlackReadThreadTool_BadPermalink(t *testing.T) {
+	tool := NewSlackReadThreadTool(SlackToolDeps{Client: &mockSlackAPI{}})
+	input, _ := json.Marshal(slackReadThreadInput{Permalink: "https://example.com/nope"})
+	if _, err := tool.Execute(context.Background(), input); err == nil {
+		t.Fatal("expected error for a non-Slack permalink")
 	}
 }
 

--- a/agent/tools/slack_search_test.go
+++ b/agent/tools/slack_search_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 
@@ -16,8 +17,16 @@ type mockSlackAPI struct {
 	repliesResult        []slack.Message
 	channels             []slack.Channel
 	users                []slack.User
+	userInfo             map[string]*slack.User
+	botInfo              map[string]*slack.Bot
+	fileInfo             *slack.File
+	downloadBody         string
+	downloadErr          error
+	downloadedURL        string
+	repliesTS            []string
 	postedChannel        string
 	postedText           string
+	postedThreadTS       string
 	postedTS             string
 	updatedTS            string
 	deletedTS            string
@@ -35,19 +44,48 @@ func (m *mockSlackAPI) SearchFiles(_ context.Context, _ string, _ slack.SearchOp
 func (m *mockSlackAPI) ConversationsHistory(_ context.Context, _ string, _ slack.HistoryOptions) ([]slack.Message, error) {
 	return m.historyResult, m.err
 }
-func (m *mockSlackAPI) ConversationsReplies(_ context.Context, _ string, _ string, _ slack.HistoryOptions) ([]slack.Message, error) {
+func (m *mockSlackAPI) ConversationsReplies(_ context.Context, _ string, ts string, _ slack.HistoryOptions) ([]slack.Message, error) {
+	m.repliesTS = append(m.repliesTS, ts)
+	return m.repliesResult, m.err
+}
+func (m *mockSlackAPI) ConversationsRepliesAll(_ context.Context, _ string, ts string, _ slack.HistoryOptions) ([]slack.Message, error) {
+	m.repliesTS = append(m.repliesTS, ts)
 	return m.repliesResult, m.err
 }
 func (m *mockSlackAPI) ConversationsList(context.Context) ([]slack.Channel, error) {
 	return m.channels, m.err
 }
 func (m *mockSlackAPI) UsersList(context.Context) ([]slack.User, error) { return m.users, m.err }
-func (m *mockSlackAPI) UsersInfo(context.Context, string) (*slack.User, error) {
+func (m *mockSlackAPI) UsersInfo(_ context.Context, id string) (*slack.User, error) {
+	if u, ok := m.userInfo[id]; ok {
+		return u, nil
+	}
 	return nil, m.err
 }
-func (m *mockSlackAPI) PostMessage(_ context.Context, channel, text, _ string) (string, error) {
+func (m *mockSlackAPI) BotsInfo(_ context.Context, id string) (*slack.Bot, error) {
+	if b, ok := m.botInfo[id]; ok {
+		return b, nil
+	}
+	return nil, m.err
+}
+func (m *mockSlackAPI) FilesInfo(context.Context, string) (*slack.File, error) {
+	if m.fileInfo != nil {
+		return m.fileInfo, nil
+	}
+	return nil, m.err
+}
+func (m *mockSlackAPI) DownloadFile(_ context.Context, url string, w io.Writer) error {
+	m.downloadedURL = url
+	if m.downloadErr != nil {
+		return m.downloadErr
+	}
+	_, err := w.Write([]byte(m.downloadBody))
+	return err
+}
+func (m *mockSlackAPI) PostMessage(_ context.Context, channel, text, threadTS string) (string, error) {
 	m.postedChannel = channel
 	m.postedText = text
+	m.postedThreadTS = threadTS
 	return m.postedTS, m.err
 }
 func (m *mockSlackAPI) UpdateMessage(_ context.Context, _, ts, _ string) error {

--- a/agent/tools/subagent_registry.go
+++ b/agent/tools/subagent_registry.go
@@ -13,8 +13,8 @@ import (
 // subagent model: guarded tools fail, subagent continues.
 type denyInteractor struct{}
 
-func (d *denyInteractor) Notify(_ string) error                { return nil }
-func (d *denyInteractor) NotifyLink(_, _ string) error         { return nil }
+func (d *denyInteractor) Notify(_ string) error        { return nil }
+func (d *denyInteractor) NotifyLink(_, _ string) error { return nil }
 func (d *denyInteractor) RequestApproval(_ string) (bool, error) {
 	return false, errors.New("not permitted in sub-agent context")
 }
@@ -22,12 +22,13 @@ func (d *denyInteractor) RequestApproval(_ string) (bool, error) {
 // SubagentRegistryDeps provides optional dependencies for building
 // an enriched subagent tool registry.
 type SubagentRegistryDeps struct {
-	ScratchDir    string
-	WebDeps       *WebToolDeps
-	LearningsDeps *LearningsDeps
-	ScheduleDeps  *ScheduleToolDeps
-	SlackClient   slack.API
-	Agents        []AgentInfo
+	ScratchDir     string
+	WebDeps        *WebToolDeps
+	LearningsDeps  *LearningsDeps
+	ScheduleDeps   *ScheduleToolDeps
+	SlackClient    slack.API
+	SlackWorkspace string
+	Agents         []AgentInfo
 }
 
 // NewSubagentRegistry creates a tool registry for subagent contexts.
@@ -61,10 +62,15 @@ func NewSubagentRegistry(deps SubagentRegistryDeps) *Registry {
 
 	// Guarded tools — denyInteractor makes them fail via GuardedAction.
 	if deps.SlackClient != nil {
-		readDeps := SlackToolDeps{Client: deps.SlackClient}
+		readDeps := SlackToolDeps{
+			Client:     deps.SlackClient,
+			Workspace:  deps.SlackWorkspace,
+			ScratchDir: deps.ScratchDir,
+		}
 		r.Register(NewSlackSearchTool(readDeps))
 		r.Register(NewSlackReadChannelTool(readDeps))
 		r.Register(NewSlackReadThreadTool(readDeps))
+		r.Register(NewSlackMediaDownloadTool(readDeps))
 		writeDeps := SlackToolDeps{Client: deps.SlackClient, Interactor: deny}
 		r.Register(NewSlackSendTool(writeDeps))
 		r.Register(NewSlackEditTool(writeDeps))
@@ -111,6 +117,7 @@ func BuildSubagentTool(cfg SubagentToolConfig) *SubagentTool {
 	if cfg.SlackWorkspace != "" {
 		if creds, err := slack.LoadCredentials(cfg.SlackWorkspace); err == nil {
 			deps.SlackClient = slack.NewClient(creds.Token, creds.Cookie)
+			deps.SlackWorkspace = cfg.SlackWorkspace
 		}
 	}
 	deps.Agents = DetectAgents()

--- a/channel/telegram/session.go
+++ b/channel/telegram/session.go
@@ -626,10 +626,16 @@ func (sm *SessionManager) registerSlackTools(reg *tools.Registry) {
 		return
 	}
 	client := slacksrc.NewClient(creds.Token, creds.Cookie)
-	deps := tools.SlackToolDeps{Client: client, Interactor: sm.interactor}
+	deps := tools.SlackToolDeps{
+		Client:     client,
+		Interactor: sm.interactor,
+		Workspace:  sm.cfg.Slack.DefaultWorkspace,
+		ScratchDir: config.ScratchDir(sm.sessionID),
+	}
 	reg.Register(tools.NewSlackSearchTool(deps))
 	reg.Register(tools.NewSlackReadChannelTool(deps))
 	reg.Register(tools.NewSlackReadThreadTool(deps))
+	reg.Register(tools.NewSlackMediaDownloadTool(deps))
 	reg.Register(tools.NewSlackSendTool(deps))
 	reg.Register(tools.NewSlackEditTool(deps))
 	reg.Register(tools.NewSlackReactTool(deps))

--- a/channel/whatsapp/session.go
+++ b/channel/whatsapp/session.go
@@ -571,10 +571,16 @@ func (sm *SessionManager) registerSlackTools(reg *tools.Registry) {
 		return
 	}
 	client := slacksrc.NewClient(creds.Token, creds.Cookie)
-	deps := tools.SlackToolDeps{Client: client, Interactor: sm.interactor}
+	deps := tools.SlackToolDeps{
+		Client:     client,
+		Interactor: sm.interactor,
+		Workspace:  sm.cfg.Slack.DefaultWorkspace,
+		ScratchDir: config.ScratchDir(sm.sessionID),
+	}
 	reg.Register(tools.NewSlackSearchTool(deps))
 	reg.Register(tools.NewSlackReadChannelTool(deps))
 	reg.Register(tools.NewSlackReadThreadTool(deps))
+	reg.Register(tools.NewSlackMediaDownloadTool(deps))
 	reg.Register(tools.NewSlackSendTool(deps))
 	reg.Register(tools.NewSlackEditTool(deps))
 	reg.Register(tools.NewSlackReactTool(deps))

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -114,7 +114,7 @@ var chatCmd = &cobra.Command{
 		registerDelegateTool(toolReg, ch, tracker)
 
 		// Register Slack tools if configured.
-		registerSlackTools(cfg, toolReg, ch)
+		registerSlackTools(cfg, toolReg, ch, scratchDir)
 
 		// Register learnings tools.
 		registerLearningsTools(toolReg)
@@ -207,7 +207,7 @@ func openAuditLogger() *audit.Logger {
 	return audit.OpenDefault(config.AuditJSONLPath())
 }
 
-func registerSlackTools(cfg *config.Config, reg *tools.Registry, ch *clicli.Channel) {
+func registerSlackTools(cfg *config.Config, reg *tools.Registry, ch *clicli.Channel, scratchDir string) {
 	if cfg.Slack == nil || cfg.Slack.DefaultWorkspace == "" {
 		return
 	}
@@ -218,11 +218,17 @@ func registerSlackTools(cfg *config.Config, reg *tools.Registry, ch *clicli.Chan
 	}
 	client := slacksrc.NewClient(creds.Token, creds.Cookie)
 	inter := NewCLIInteractor(ch)
-	deps := tools.SlackToolDeps{Client: client, Interactor: inter}
+	deps := tools.SlackToolDeps{
+		Client:     client,
+		Interactor: inter,
+		Workspace:  cfg.Slack.DefaultWorkspace,
+		ScratchDir: scratchDir,
+	}
 
 	reg.Register(tools.NewSlackSearchTool(deps))
 	reg.Register(tools.NewSlackReadChannelTool(deps))
 	reg.Register(tools.NewSlackReadThreadTool(deps))
+	reg.Register(tools.NewSlackMediaDownloadTool(deps))
 	reg.Register(tools.NewSlackSendTool(deps))
 	reg.Register(tools.NewSlackEditTool(deps))
 	reg.Register(tools.NewSlackReactTool(deps))

--- a/internal/cli/slack/media.go
+++ b/internal/cli/slack/media.go
@@ -1,0 +1,56 @@
+package slack
+
+import (
+	"fmt"
+	"os"
+
+	slacksrc "github.com/73ai/openbotkit/source/slack"
+	"github.com/spf13/cobra"
+)
+
+var mediaCmd = &cobra.Command{
+	Use:   "media",
+	Short: "Work with Slack files",
+}
+
+var mediaDownloadCmd = &cobra.Command{
+	Use:   "download <url>",
+	Short: "Download a Slack file to stdout",
+	Long: `Download a Slack file and write its bytes to stdout.
+
+Accepts a url_private from a message's files[], or a /files/… permalink.
+Progress and errors go to stderr, so stdout can be redirected to a file.`,
+	Example: `  obk slack media download https://files.slack.com/files-pri/T1-F1/shot.jpg > shot.jpg
+  obk slack media download https://acme.slack.com/files/U01ABC/F01ABC/shot.jpg > shot.jpg`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if stdoutIsTerminal() {
+			return fmt.Errorf("refusing to write binary data to the terminal; redirect it: obk slack media download %s > file", args[0])
+		}
+
+		client, err := loadClient()
+		if err != nil {
+			return err
+		}
+
+		downloadURL, err := slacksrc.ResolveFileURL(cmd.Context(), client, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "downloading %s\n", downloadURL)
+
+		return client.DownloadFile(cmd.Context(), downloadURL, os.Stdout)
+	},
+}
+
+func stdoutIsTerminal() bool {
+	info, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func init() {
+	mediaCmd.AddCommand(mediaDownloadCmd)
+}

--- a/internal/cli/slack/media_test.go
+++ b/internal/cli/slack/media_test.go
@@ -1,0 +1,47 @@
+package slack
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestMediaDownloadCmd_RequiresOneURL(t *testing.T) {
+	Cmd.SetOut(io.Discard)
+	Cmd.SetErr(io.Discard)
+	Cmd.SetArgs([]string{"media", "download"})
+	t.Cleanup(func() { Cmd.SetArgs(nil) })
+
+	err := Cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no URL is given")
+	}
+	if !strings.Contains(err.Error(), "arg") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestMediaCmd_Registered(t *testing.T) {
+	var found bool
+	for _, c := range Cmd.Commands() {
+		if c.Name() == "media" {
+			found = true
+			for _, sub := range c.Commands() {
+				if sub.Name() == "download" {
+					return
+				}
+			}
+			t.Fatal("media has no download subcommand")
+		}
+	}
+	if !found {
+		t.Fatal("media command not registered")
+	}
+}
+
+// Under `go test` stdout is a pipe, so the binary-to-terminal guard stays off.
+func TestStdoutIsTerminal_FalseWhenRedirected(t *testing.T) {
+	if stdoutIsTerminal() {
+		t.Error("stdout should not look like a terminal in tests")
+	}
+}

--- a/internal/cli/slack/reply.go
+++ b/internal/cli/slack/reply.go
@@ -1,0 +1,123 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	slacksrc "github.com/73ai/openbotkit/source/slack"
+	"github.com/spf13/cobra"
+)
+
+var replyCmd = &cobra.Command{
+	Use:   "reply [permalink]",
+	Short: "Post a reply in a Slack thread",
+	Long: `Post a reply in a Slack thread, as you.
+
+Accepts a message permalink, or --channel-id plus --thread-id. The body comes
+from --text or from stdin; piped stdin wins. It is sent verbatim, so Slack
+mrkdwn is your responsibility. The message posts immediately, with no
+confirmation prompt.`,
+	Example: `  obk slack reply https://acme.slack.com/archives/C01ABC23DEF/p1785334150236249 --text "fixed in v2.4"
+  echo "fixed in v2.4" | obk slack reply --channel-id C01ABC23DEF --thread-id p1785334150236249`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		channelFlag, _ := cmd.Flags().GetString("channel-id")
+		threadFlag, _ := cmd.Flags().GetString("thread-id")
+		text, _ := cmd.Flags().GetString("text")
+
+		if len(args) == 1 && (channelFlag != "" || threadFlag != "") {
+			return fmt.Errorf("pass a permalink or --channel-id/--thread-id, not both")
+		}
+		if len(args) == 0 && (channelFlag == "" || threadFlag == "") {
+			return fmt.Errorf("pass a permalink, or both --channel-id and --thread-id")
+		}
+
+		if piped, err := readPipedStdin(); err != nil {
+			return err
+		} else if piped != "" {
+			text = piped
+		}
+		if text == "" {
+			return fmt.Errorf("empty message; pass --text or pipe the body on stdin")
+		}
+
+		client, _, workspace, err := loadClientAndCache()
+		if err != nil {
+			return err
+		}
+
+		var channelID, ts string
+		if len(args) == 1 {
+			ref, err := slacksrc.ParsePermalink(args[0])
+			if err != nil {
+				return err
+			}
+			if !slacksrc.MatchesWorkspace(ref.Subdomain, workspace) {
+				return fmt.Errorf("permalink belongs to workspace %q but obk is authenticated to %q; run: obk slack auth login", ref.Subdomain, workspace)
+			}
+			channelID = ref.ChannelID
+			if ts, err = ref.RootTS(); err != nil {
+				return err
+			}
+		} else {
+			if channelID, err = client.ResolveChannel(cmd.Context(), channelFlag); err != nil {
+				return fmt.Errorf("resolve channel: %w", err)
+			}
+			if ts, err = slacksrc.MessageIDToTS(threadFlag); err != nil {
+				return err
+			}
+		}
+
+		// Slack wants the thread parent, so a link to a reply is walked up first.
+		rootTS, err := slacksrc.ResolveThreadRoot(cmd.Context(), client, channelID, ts)
+		if err != nil {
+			return err
+		}
+
+		postedTS, err := client.PostMessage(cmd.Context(), channelID, text, rootTS)
+		if err != nil {
+			return fmt.Errorf("post reply: %w", err)
+		}
+
+		out := map[string]string{
+			"channel_id": channelID,
+			"thread_id":  slacksrc.TSToMessageID(rootTS),
+			"ts":         postedTS,
+			"message_id": slacksrc.TSToMessageID(postedTS),
+		}
+		if link, err := client.GetPermalink(cmd.Context(), channelID, postedTS); err == nil {
+			out["permalink"] = link
+		} else {
+			fmt.Fprintf(os.Stderr, "posted, but could not fetch permalink: %v\n", err)
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	},
+}
+
+// readPipedStdin returns stdin when it is a pipe or file, and "" when it is a
+// terminal, so an interactive run does not block waiting for input.
+func readPipedStdin() (string, error) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return "", nil
+	}
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return "", nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(data), nil
+}
+
+func init() {
+	replyCmd.Flags().String("channel-id", "", "Channel ID or name (with --thread-id)")
+	replyCmd.Flags().String("thread-id", "", "Message ID of any message in the thread, e.g. p1785334150236249")
+	replyCmd.Flags().String("text", "", "Message body; omit to read from stdin")
+}

--- a/internal/cli/slack/reply.go
+++ b/internal/cli/slack/reply.go
@@ -34,6 +34,13 @@ confirmation prompt.`,
 			return fmt.Errorf("pass a permalink, or both --channel-id and --thread-id")
 		}
 
+		// Parse the address before loading credentials, so bad input fails
+		// on its own terms instead of on a missing workspace.
+		ref, flagTS, err := parseThreadAddress(args, threadFlag)
+		if err != nil {
+			return err
+		}
+
 		if piped, err := readPipedStdin(); err != nil {
 			return err
 		} else if piped != "" {
@@ -49,11 +56,7 @@ confirmation prompt.`,
 		}
 
 		var channelID, ts string
-		if len(args) == 1 {
-			ref, err := slacksrc.ParsePermalink(args[0])
-			if err != nil {
-				return err
-			}
+		if ref != nil {
 			if !slacksrc.MatchesWorkspace(ref.Subdomain, workspace) {
 				return fmt.Errorf("permalink belongs to workspace %q but obk is authenticated to %q; run: obk slack auth login", ref.Subdomain, workspace)
 			}
@@ -65,9 +68,7 @@ confirmation prompt.`,
 			if channelID, err = client.ResolveChannel(cmd.Context(), channelFlag); err != nil {
 				return fmt.Errorf("resolve channel: %w", err)
 			}
-			if ts, err = slacksrc.MessageIDToTS(threadFlag); err != nil {
-				return err
-			}
+			ts = flagTS
 		}
 
 		// Slack wants the thread parent, so a link to a reply is walked up first.

--- a/internal/cli/slack/reply_test.go
+++ b/internal/cli/slack/reply_test.go
@@ -1,0 +1,60 @@
+package slack
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func runReply(t *testing.T, args ...string) error {
+	t.Helper()
+	replyCmd.Flags().Set("channel-id", "")
+	replyCmd.Flags().Set("thread-id", "")
+	replyCmd.Flags().Set("text", "")
+	Cmd.SetOut(io.Discard)
+	Cmd.SetErr(io.Discard)
+	Cmd.SetArgs(append([]string{"reply"}, args...))
+	t.Cleanup(func() { Cmd.SetArgs(nil) })
+	return Cmd.Execute()
+}
+
+func TestReplyCmd_RequiresAnAddress(t *testing.T) {
+	err := runReply(t, "--text", "hello")
+	if err == nil {
+		t.Fatal("expected error when neither permalink nor flags are given")
+	}
+	if !strings.Contains(err.Error(), "--channel-id") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestReplyCmd_RejectsBothForms(t *testing.T) {
+	err := runReply(t,
+		"https://acme.slack.com/archives/C01ABC23DEF/p1785334150236249",
+		"--channel-id", "C01ABC23DEF", "--text", "hello",
+	)
+	if err == nil {
+		t.Fatal("expected error when both a permalink and flags are given")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+// Under `go test` stdin is not a pipe, so an empty --text has no fallback.
+func TestReplyCmd_RejectsEmptyBody(t *testing.T) {
+	err := runReply(t, "https://acme.slack.com/archives/C01ABC23DEF/p1785334150236249")
+	if err == nil {
+		t.Fatal("expected error for an empty body")
+	}
+	if !strings.Contains(err.Error(), "empty message") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestReplyCmd_RejectsMalformedPermalink(t *testing.T) {
+	err := runReply(t, "https://example.com/not-slack", "--text", "hello")
+	if err == nil {
+		t.Fatal("expected error for a non-Slack URL")
+	}
+}

--- a/internal/cli/slack/reply_test.go
+++ b/internal/cli/slack/reply_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 )
 
+// OBK_CONFIG_DIR points at an empty dir so the test never sees the developer's
+// real Slack config and behaves the same here as in CI.
 func runReply(t *testing.T, args ...string) error {
 	t.Helper()
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
 	replyCmd.Flags().Set("channel-id", "")
 	replyCmd.Flags().Set("thread-id", "")
 	replyCmd.Flags().Set("text", "")
@@ -56,5 +59,11 @@ func TestReplyCmd_RejectsMalformedPermalink(t *testing.T) {
 	err := runReply(t, "https://example.com/not-slack", "--text", "hello")
 	if err == nil {
 		t.Fatal("expected error for a non-Slack URL")
+	}
+	if !strings.Contains(err.Error(), "Slack permalink") {
+		t.Errorf("error = %q", err)
+	}
+	if strings.Contains(err.Error(), "no Slack workspace configured") {
+		t.Errorf("credentials were loaded before validating input: %q", err)
 	}
 }

--- a/internal/cli/slack/slack.go
+++ b/internal/cli/slack/slack.go
@@ -44,4 +44,5 @@ func init() {
 	Cmd.AddCommand(readCmd)
 	Cmd.AddCommand(threadCmd)
 	Cmd.AddCommand(mediaCmd)
+	Cmd.AddCommand(replyCmd)
 }

--- a/internal/cli/slack/slack.go
+++ b/internal/cli/slack/slack.go
@@ -14,18 +14,27 @@ var Cmd = &cobra.Command{
 }
 
 func loadClient() (*slacksrc.Client, error) {
+	client, _, _, err := loadClientAndCache()
+	return client, err
+}
+
+// loadClientAndCache also returns the user name cache and the workspace it is
+// keyed on, for commands that resolve IDs to names.
+func loadClientAndCache() (*slacksrc.Client, *slacksrc.UserCache, string, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
+		return nil, nil, "", fmt.Errorf("load config: %w", err)
 	}
 	if cfg.Slack == nil || cfg.Slack.DefaultWorkspace == "" {
-		return nil, fmt.Errorf("no Slack workspace configured; run: obk slack auth login")
+		return nil, nil, "", fmt.Errorf("no Slack workspace configured; run: obk slack auth login")
 	}
-	creds, err := slacksrc.LoadCredentials(cfg.Slack.DefaultWorkspace)
+	workspace := cfg.Slack.DefaultWorkspace
+	creds, err := slacksrc.LoadCredentials(workspace)
 	if err != nil {
-		return nil, fmt.Errorf("load credentials: %w", err)
+		return nil, nil, "", fmt.Errorf("load credentials: %w", err)
 	}
-	return slacksrc.NewClient(creds.Token, creds.Cookie), nil
+	client := slacksrc.NewClient(creds.Token, creds.Cookie)
+	return client, slacksrc.NewUserCache(workspace, client), workspace, nil
 }
 
 func init() {
@@ -33,4 +42,5 @@ func init() {
 	Cmd.AddCommand(searchCmd)
 	Cmd.AddCommand(channelsCmd)
 	Cmd.AddCommand(readCmd)
+	Cmd.AddCommand(threadCmd)
 }

--- a/internal/cli/slack/slack.go
+++ b/internal/cli/slack/slack.go
@@ -43,4 +43,5 @@ func init() {
 	Cmd.AddCommand(channelsCmd)
 	Cmd.AddCommand(readCmd)
 	Cmd.AddCommand(threadCmd)
+	Cmd.AddCommand(mediaCmd)
 }

--- a/internal/cli/slack/thread.go
+++ b/internal/cli/slack/thread.go
@@ -32,6 +32,13 @@ the thread works: a link to a reply returns the whole thread.`,
 			return fmt.Errorf("pass a permalink, or both --channel-id and --thread-id")
 		}
 
+		// Parse the address before loading credentials, so bad input fails
+		// on its own terms instead of on a missing workspace.
+		ref, flagTS, err := parseThreadAddress(args, threadFlag)
+		if err != nil {
+			return err
+		}
+
 		client, cache, workspace, err := loadClientAndCache()
 		if err != nil {
 			return err
@@ -41,11 +48,7 @@ the thread works: a link to a reply returns the whole thread.`,
 		}
 
 		var channelID, ts string
-		if len(args) == 1 {
-			ref, err := slacksrc.ParsePermalink(args[0])
-			if err != nil {
-				return err
-			}
+		if ref != nil {
 			if !slacksrc.MatchesWorkspace(ref.Subdomain, workspace) {
 				return fmt.Errorf("permalink belongs to workspace %q but obk is authenticated to %q; run: obk slack auth login", ref.Subdomain, workspace)
 			}
@@ -57,9 +60,7 @@ the thread works: a link to a reply returns the whole thread.`,
 			if channelID, err = client.ResolveChannel(cmd.Context(), channelFlag); err != nil {
 				return fmt.Errorf("resolve channel: %w", err)
 			}
-			if ts, err = slacksrc.MessageIDToTS(threadFlag); err != nil {
-				return err
-			}
+			ts = flagTS
 		}
 
 		thread, err := slacksrc.FetchThread(cmd.Context(), client, cache, channelID, ts)
@@ -71,6 +72,23 @@ the thread works: a link to a reply returns the whole thread.`,
 		enc.SetIndent("", "  ")
 		return enc.Encode(thread)
 	},
+}
+
+// parseThreadAddress validates the permalink or --thread-id form. It needs no
+// config or network, so callers run it before loading credentials.
+func parseThreadAddress(args []string, threadFlag string) (*slacksrc.MessageRef, string, error) {
+	if len(args) == 1 {
+		ref, err := slacksrc.ParsePermalink(args[0])
+		if err != nil {
+			return nil, "", err
+		}
+		return ref, "", nil
+	}
+	ts, err := slacksrc.MessageIDToTS(threadFlag)
+	if err != nil {
+		return nil, "", err
+	}
+	return nil, ts, nil
 }
 
 func init() {

--- a/internal/cli/slack/thread.go
+++ b/internal/cli/slack/thread.go
@@ -1,0 +1,80 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	slacksrc "github.com/73ai/openbotkit/source/slack"
+	"github.com/spf13/cobra"
+)
+
+var threadCmd = &cobra.Command{
+	Use:   "thread [permalink]",
+	Short: "Read a complete Slack thread as JSON",
+	Long: `Read every message in a Slack thread, with user IDs resolved to names.
+
+Accepts a message permalink, or --channel-id plus --thread-id. Any message in
+the thread works: a link to a reply returns the whole thread.`,
+	Example: `  obk slack thread https://acme.slack.com/archives/C01ABC23DEF/p1785334150236249
+  obk slack thread --channel-id C01ABC23DEF --thread-id p1785334150236249
+  obk slack thread --channel-id support --thread-id p1785334150236249`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		channelFlag, _ := cmd.Flags().GetString("channel-id")
+		threadFlag, _ := cmd.Flags().GetString("thread-id")
+		refreshUsers, _ := cmd.Flags().GetBool("refresh-users")
+
+		if len(args) == 1 && (channelFlag != "" || threadFlag != "") {
+			return fmt.Errorf("pass a permalink or --channel-id/--thread-id, not both")
+		}
+		if len(args) == 0 && (channelFlag == "" || threadFlag == "") {
+			return fmt.Errorf("pass a permalink, or both --channel-id and --thread-id")
+		}
+
+		client, cache, workspace, err := loadClientAndCache()
+		if err != nil {
+			return err
+		}
+		if refreshUsers {
+			cache.Refresh()
+		}
+
+		var channelID, ts string
+		if len(args) == 1 {
+			ref, err := slacksrc.ParsePermalink(args[0])
+			if err != nil {
+				return err
+			}
+			if !slacksrc.MatchesWorkspace(ref.Subdomain, workspace) {
+				return fmt.Errorf("permalink belongs to workspace %q but obk is authenticated to %q; run: obk slack auth login", ref.Subdomain, workspace)
+			}
+			channelID = ref.ChannelID
+			if ts, err = ref.RootTS(); err != nil {
+				return err
+			}
+		} else {
+			if channelID, err = client.ResolveChannel(cmd.Context(), channelFlag); err != nil {
+				return fmt.Errorf("resolve channel: %w", err)
+			}
+			if ts, err = slacksrc.MessageIDToTS(threadFlag); err != nil {
+				return err
+			}
+		}
+
+		thread, err := slacksrc.FetchThread(cmd.Context(), client, cache, channelID, ts)
+		if err != nil {
+			return err
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(thread)
+	},
+}
+
+func init() {
+	threadCmd.Flags().String("channel-id", "", "Channel ID or name (with --thread-id)")
+	threadCmd.Flags().String("thread-id", "", "Message ID of any message in the thread, e.g. p1785334150236249")
+	threadCmd.Flags().Bool("refresh-users", false, "Re-fetch user names instead of using the cache")
+}

--- a/internal/cli/slack/thread_test.go
+++ b/internal/cli/slack/thread_test.go
@@ -7,8 +7,11 @@ import (
 )
 
 // runThread executes the thread command with fresh flags and returns its error.
+// OBK_CONFIG_DIR points at an empty dir so the test never sees the developer's
+// real Slack config and behaves the same here as in CI.
 func runThread(t *testing.T, args ...string) error {
 	t.Helper()
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
 	threadCmd.Flags().Set("channel-id", "")
 	threadCmd.Flags().Set("thread-id", "")
 	threadCmd.Flags().Set("refresh-users", "false")
@@ -56,5 +59,27 @@ func TestThreadCmd_RejectsMalformedPermalink(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Slack permalink") {
 		t.Errorf("error = %q", err)
+	}
+}
+
+func TestThreadCmd_RejectsMalformedThreadID(t *testing.T) {
+	err := runThread(t, "--channel-id", "C01ABC23DEF", "--thread-id", "p123")
+	if err == nil {
+		t.Fatal("expected error for a malformed message ID")
+	}
+	if !strings.Contains(err.Error(), "invalid message ID") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+// Address parsing must not depend on credentials: with no workspace
+// configured, malformed input still reports what is actually wrong.
+func TestThreadCmd_AddressCheckedBeforeCredentials(t *testing.T) {
+	err := runThread(t, "https://example.com/not-slack")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "no Slack workspace configured") {
+		t.Errorf("credentials were loaded before validating input: %q", err)
 	}
 }

--- a/internal/cli/slack/thread_test.go
+++ b/internal/cli/slack/thread_test.go
@@ -1,0 +1,60 @@
+package slack
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// runThread executes the thread command with fresh flags and returns its error.
+func runThread(t *testing.T, args ...string) error {
+	t.Helper()
+	threadCmd.Flags().Set("channel-id", "")
+	threadCmd.Flags().Set("thread-id", "")
+	threadCmd.Flags().Set("refresh-users", "false")
+	Cmd.SetOut(io.Discard)
+	Cmd.SetErr(io.Discard)
+	Cmd.SetArgs(append([]string{"thread"}, args...))
+	t.Cleanup(func() { Cmd.SetArgs(nil) })
+	return Cmd.Execute()
+}
+
+func TestThreadCmd_RequiresAnAddress(t *testing.T) {
+	err := runThread(t)
+	if err == nil {
+		t.Fatal("expected error when neither permalink nor flags are given")
+	}
+	if !strings.Contains(err.Error(), "--channel-id") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestThreadCmd_RejectsBothForms(t *testing.T) {
+	err := runThread(t,
+		"https://acme.slack.com/archives/C01ABC23DEF/p1785334150236249",
+		"--channel-id", "C01ABC23DEF",
+	)
+	if err == nil {
+		t.Fatal("expected error when both a permalink and flags are given")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestThreadCmd_RejectsPartialFlags(t *testing.T) {
+	err := runThread(t, "--channel-id", "C01ABC23DEF")
+	if err == nil {
+		t.Fatal("expected error when --thread-id is missing")
+	}
+}
+
+func TestThreadCmd_RejectsMalformedPermalink(t *testing.T) {
+	err := runThread(t, "https://example.com/not-slack")
+	if err == nil {
+		t.Fatal("expected error for a non-Slack URL")
+	}
+	if !strings.Contains(err.Error(), "Slack permalink") {
+		t.Errorf("error = %q", err)
+	}
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -24,6 +24,7 @@ var builtinSkills = map[string]SkillMeta{
 	"email-send":      {Scopes: []string{"https://www.googleapis.com/auth/gmail.modify"}, Write: true},
 	"whatsapp-read":   {RequiresAuth: "whatsapp"},
 	"whatsapp-send":   {RequiresAuth: "whatsapp", Write: true},
+	"slack-thread":    {RequiresAuth: "slack", Write: true},
 	"history-read":    {},
 	"memory-save":     {},
 	"web-search":      {},

--- a/skills/slack-thread/REFERENCE.md
+++ b/skills/slack-thread/REFERENCE.md
@@ -1,0 +1,132 @@
+## When to use
+
+- Someone shares a Slack permalink and you need the conversation behind it
+- You need a whole thread including every reply, not just the one linked message
+- Catching up on or summarising a discussion that happened in a thread
+- You need a file or image attached to a thread — they carry content that is nowhere in the text
+- Replying inside an existing thread
+
+## When NOT to use
+
+- Reading a channel's recent messages — use `obk slack read <channel>`
+- Searching across Slack — use `obk slack search "<query>"`
+- Sending a new message that isn't a reply to an existing thread
+
+## Commands
+
+### Read a thread
+
+```bash
+obk slack thread https://acme.slack.com/archives/C01Q9G9CD6X/p1785334150236249
+obk slack thread --channel-id C01Q9G9CD6X --thread-id p1785334150236249
+obk slack thread --channel-id support --thread-id p1785334150236249
+```
+
+Pass a permalink **or** `--channel-id` + `--thread-id`, never both. `--channel-id` also accepts a
+channel name. Any message in the thread works — a link to a reply returns the whole thread, so you
+never need to hunt for the root.
+
+Add `--refresh-users` to re-fetch display names instead of using the cache.
+
+Output is JSON:
+
+```json
+{
+  "channel_id": "C01Q9G9CD6X",
+  "thread_id": "p1785334150236249",
+  "thread_ts": "1785334150.236249",
+  "users": { "U02ABC": "rahul.support", "U04DEF": "priya.eng" },
+  "messages": [
+    {
+      "message_id": "p1785334150236249",
+      "ts": "1785334150.236249",
+      "user": "U02ABC",
+      "user_name": "rahul.support",
+      "text": "<@U04DEF> can you check <#C02XY|ledger>?",
+      "files": [{ "id": "F0BL9", "name": "shot.png", "url_private": "https://files.slack.com/..." }]
+    }
+  ]
+}
+```
+
+Message text is **raw** — mentions stay as `<@U04DEF>`. Use the top-level `users` map to decode
+them. That map covers everyone referenced anywhere in the thread: authors, mentions, reaction
+voters, editors, and bots. Channel refs like `<#C02XY|ledger>` already carry the name inline.
+
+Messages also carry `attachments` and `blocks` when present. Bots and integrations put their real
+payload in `attachments`, so check there when `text` looks empty.
+
+### Download a file from the thread
+
+```bash
+obk slack media download "<url_private>" > shot.png
+obk slack media download "https://acme.slack.com/files/U01ABC/F01ABC/shot.png" > shot.png
+```
+
+Takes a `url_private` from a message's `files[]`, or a `/files/…` permalink. Writes the bytes to
+**stdout**, so you must redirect to a file — it refuses to dump binary into a terminal. Logs and
+errors go to stderr, so the redirect stays clean.
+
+Then read the file. For images, that means you can actually see what was shared.
+
+### Reply to the thread
+
+```bash
+obk slack reply https://acme.slack.com/archives/C01Q9G9CD6X/p1785334150236249 --text "fixed in v2.4"
+echo "fixed in v2.4" | obk slack reply --channel-id C01Q9G9CD6X --thread-id p1785334150236249
+```
+
+Same addressing as `thread`. The body comes from `--text` or stdin; piped stdin wins. It is sent
+**verbatim** — no markdown conversion, so write Slack mrkdwn (`*bold*`, not `**bold**`). Multi-line
+bodies and code fences survive intact. On success it prints JSON including the new message's
+permalink.
+
+> [!CAUTION]
+> `reply` posts immediately as you. There is no confirmation prompt and no undo. Confirm the
+> target thread with the user before replying to anything you did not just read.
+
+## Examples
+
+Reading a thread, opening what was shared in it, and replying:
+
+```bash
+# 1. Read the thread the user linked
+obk slack thread "https://acme.slack.com/archives/C01Q9G9CD6X/p1785334150236249" > /tmp/thread.json
+
+# 2. List the files attached anywhere in it
+jq -r '.messages[].files[]?.url_private' /tmp/thread.json
+
+# 3. Download one and read it
+obk slack media download "https://files.slack.com/files-pri/T1-F0BL9/shot.png" > /tmp/shot.png
+
+# 4. Reply in the thread
+obk slack reply "https://acme.slack.com/archives/C01Q9G9CD6X/p1785334150236249" \
+  --text "confirmed, shipping in v2.4"
+```
+
+Summarising a thread without replying:
+
+```bash
+obk slack thread "<permalink>" | jq -r '.messages[] | "\(.user_name // .user): \(.text)"'
+```
+
+Decoding a mention using the `users` map:
+
+```bash
+# text: "<@U04DEF> can you check this?"  ->  users["U04DEF"] == "priya.eng"
+jq '.users' /tmp/thread.json
+```
+
+## Notes
+
+- Requires `obk slack auth login`.
+- Names are cached per workspace in `~/.obk/slack/users-<workspace>.json`, so repeat runs cost no
+  API calls. Use `--refresh-users` if someone changed their display name.
+- Auth for file downloads uses the Slack Desktop cookie, which expires. If a download fails with
+  "got an HTML page instead of the file", the credentials are stale — run `obk slack auth login`.
+  The command errors instead of writing that login page into your image file.
+- A permalink from a different workspace than the one you're authenticated to is rejected with an
+  explicit error rather than a confusing `channel_not_found`.
+- DM (`D…`), private group (`G…`), and public channel (`C…`) permalinks all work.
+- Long threads are fully paginated — no silent truncation.
+- Bulk-downloading every file in a thread is not supported; download them one URL at a time.

--- a/skills/slack-thread/SKILL.md
+++ b/skills/slack-thread/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: slack-thread
+description: Work with a Slack thread from a permalink — read the whole thread, download its files, reply in-thread
+allowed-tools: Bash(obk *), file_read
+---
+
+Read a complete Slack thread, download the files attached to it, and reply — all from a message permalink.
+
+Read the REFERENCE.md in this skill's directory for full instructions.

--- a/source/slack/api.go
+++ b/source/slack/api.go
@@ -1,15 +1,22 @@
 package slack
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 type API interface {
 	SearchMessages(ctx context.Context, query string, opts SearchOptions) (*SearchResult, error)
 	SearchFiles(ctx context.Context, query string, opts SearchOptions) (*FileSearchResult, error)
 	ConversationsHistory(ctx context.Context, channel string, opts HistoryOptions) ([]Message, error)
 	ConversationsReplies(ctx context.Context, channel, threadTS string, opts HistoryOptions) ([]Message, error)
+	ConversationsRepliesAll(ctx context.Context, channel, threadTS string, opts HistoryOptions) ([]Message, error)
 	ConversationsList(ctx context.Context) ([]Channel, error)
 	UsersList(ctx context.Context) ([]User, error)
 	UsersInfo(ctx context.Context, userID string) (*User, error)
+	BotsInfo(ctx context.Context, botID string) (*Bot, error)
+	FilesInfo(ctx context.Context, fileID string) (*File, error)
+	DownloadFile(ctx context.Context, url string, w io.Writer) error
 	PostMessage(ctx context.Context, channel, text, threadTS string) (string, error)
 	UpdateMessage(ctx context.Context, channel, ts, text string) error
 	DeleteMessage(ctx context.Context, channel, ts string) error

--- a/source/slack/client.go
+++ b/source/slack/client.go
@@ -123,9 +123,9 @@ func (c *Client) SearchMessages(ctx context.Context, query string, opts SearchOp
 
 	var resp struct {
 		Messages struct {
-			Total   int `json:"total"`
-			Page    int `json:"page"`
-			Pages   int `json:"pages"`
+			Total   int       `json:"total"`
+			Page    int       `json:"page"`
+			Pages   int       `json:"pages"`
 			Matches []Message `json:"matches"`
 		} `json:"messages"`
 	}
@@ -340,6 +340,73 @@ func (c *Client) UsersInfo(ctx context.Context, userID string) (*User, error) {
 		return nil, fmt.Errorf("parse user info: %w", err)
 	}
 	return &resp.User, nil
+}
+
+func (c *Client) FilesInfo(ctx context.Context, fileID string) (*File, error) {
+	body, err := c.call(ctx, "files.info", url.Values{"file": {fileID}})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		File File `json:"file"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse file info: %w", err)
+	}
+	return &resp.File, nil
+}
+
+func (c *Client) BotsInfo(ctx context.Context, botID string) (*Bot, error) {
+	body, err := c.call(ctx, "bots.info", url.Values{"bot": {botID}})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Bot Bot `json:"bot"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse bot info: %w", err)
+	}
+	return &resp.Bot, nil
+}
+
+// DownloadFile streams a Slack file URL to w. Slack serves an HTML login page
+// with HTTP 200 when auth fails, so the content type is checked before any
+// bytes reach the writer.
+func (c *Client) DownloadFile(ctx context.Context, rawURL string, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if c.isBrowserToken() {
+		req.Header.Set("Cookie", "d="+c.cookie)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.downloadClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("download %s: HTTP %d", rawURL, resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); strings.HasPrefix(ct, "text/html") {
+		return fmt.Errorf("download %s: got an HTML page instead of the file, credentials are missing or expired; run: obk slack auth login", rawURL)
+	}
+
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) downloadClient() *http.Client {
+	return &http.Client{Timeout: 5 * time.Minute}
 }
 
 // Write methods

--- a/source/slack/client.go
+++ b/source/slack/client.go
@@ -434,6 +434,26 @@ func (c *Client) PostMessage(ctx context.Context, channel, text, threadTS string
 	return resp.TS, nil
 }
 
+// GetPermalink returns the public link to a message. The workspace subdomain
+// is not stored locally, so the link cannot be built without asking Slack.
+func (c *Client) GetPermalink(ctx context.Context, channel, ts string) (string, error) {
+	body, err := c.call(ctx, "chat.getPermalink", url.Values{
+		"channel":    {channel},
+		"message_ts": {ts},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var resp struct {
+		Permalink string `json:"permalink"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("parse permalink: %w", err)
+	}
+	return resp.Permalink, nil
+}
+
 func (c *Client) UpdateMessage(ctx context.Context, channel, ts, text string) error {
 	_, err := c.call(ctx, "chat.update", url.Values{
 		"channel": {channel},

--- a/source/slack/client.go
+++ b/source/slack/client.go
@@ -205,6 +205,36 @@ func (c *Client) ConversationsHistory(ctx context.Context, channel string, opts 
 }
 
 func (c *Client) ConversationsReplies(ctx context.Context, channel, threadTS string, opts HistoryOptions) ([]Message, error) {
+	msgs, _, err := c.repliesPage(ctx, channel, threadTS, opts)
+	return msgs, err
+}
+
+// ConversationsRepliesAll follows next_cursor until the whole thread is fetched.
+func (c *Client) ConversationsRepliesAll(ctx context.Context, channel, threadTS string, opts HistoryOptions) ([]Message, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 200
+	}
+
+	var all []Message
+	for {
+		msgs, cursor, err := c.repliesPage(ctx, channel, threadTS, opts)
+		if err != nil {
+			return nil, err
+		}
+		// Every page repeats the thread parent; keep it only from the first.
+		if len(all) > 0 && len(msgs) > 0 && msgs[0].TS == all[0].TS {
+			msgs = msgs[1:]
+		}
+		all = append(all, msgs...)
+
+		if cursor == "" {
+			return all, nil
+		}
+		opts.Cursor = cursor
+	}
+}
+
+func (c *Client) repliesPage(ctx context.Context, channel, threadTS string, opts HistoryOptions) ([]Message, string, error) {
 	params := url.Values{
 		"channel": {channel},
 		"ts":      {threadTS},
@@ -218,16 +248,17 @@ func (c *Client) ConversationsReplies(ctx context.Context, channel, threadTS str
 
 	body, err := c.call(ctx, "conversations.replies", params)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	var resp struct {
 		Messages []Message `json:"messages"`
+		apiResponse
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parse replies: %w", err)
+		return nil, "", fmt.Errorf("parse replies: %w", err)
 	}
-	return resp.Messages, nil
+	return resp.Messages, resp.Metadata.NextCursor, nil
 }
 
 func (c *Client) ConversationsList(ctx context.Context) ([]Channel, error) {

--- a/source/slack/client_test.go
+++ b/source/slack/client_test.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -413,6 +414,138 @@ func TestClient_UsersInfo(t *testing.T) {
 	}
 	if user.Name != "alice" {
 		t.Errorf("name = %q", user.Name)
+	}
+}
+
+func TestClient_FilesInfo(t *testing.T) {
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.FormValue("file") != "F123" {
+			t.Errorf("file = %q", r.FormValue("file"))
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"file": map[string]any{
+				"id":          "F123",
+				"name":        "screenshot.png",
+				"mimetype":    "image/png",
+				"url_private": "https://files.slack.com/files-pri/T1-F123/screenshot.png",
+			},
+		})
+	})
+
+	f, err := c.FilesInfo(context.Background(), "F123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Name != "screenshot.png" || f.Mimetype != "image/png" {
+		t.Errorf("file = %+v", f)
+	}
+	if f.URLPrivate == "" {
+		t.Error("url_private missing")
+	}
+}
+
+func TestClient_BotsInfo(t *testing.T) {
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.FormValue("bot") != "B123" {
+			t.Errorf("bot = %q", r.FormValue("bot"))
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":  true,
+			"bot": map[string]any{"id": "B123", "name": "Sentry"},
+		})
+	})
+
+	b, err := c.BotsInfo(context.Background(), "B123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Name != "Sentry" {
+		t.Errorf("name = %q", b.Name)
+	}
+}
+
+func TestClient_DownloadFile(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("\x89PNG\r\n\x1a\nfake image bytes"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("xoxp-test-token", "")
+	var buf bytes.Buffer
+	if err := c.DownloadFile(context.Background(), srv.URL+"/files-pri/T1-F1/shot.png", &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte("\x89PNG")) {
+		t.Errorf("body = %q", buf.String())
+	}
+	if gotAuth != "Bearer xoxp-test-token" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+}
+
+func TestClient_DownloadFile_BrowserAuth(t *testing.T) {
+	var gotCookie, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCookie = r.Header.Get("Cookie")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("jpegdata"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("xoxc-browser-token", "xoxd-cookie")
+	var buf bytes.Buffer
+	if err := c.DownloadFile(context.Background(), srv.URL+"/shot.jpeg", &buf); err != nil {
+		t.Fatal(err)
+	}
+	if gotCookie != "d=xoxd-cookie" {
+		t.Errorf("cookie = %q", gotCookie)
+	}
+	if gotAuth != "" {
+		t.Errorf("browser download should not send Authorization, got %q", gotAuth)
+	}
+}
+
+// Slack answers an unauthenticated file request with HTTP 200 and a login
+// page; without a content-type check that HTML lands in the output file.
+func TestClient_DownloadFile_HTMLLoginPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(200)
+		w.Write([]byte("<!DOCTYPE html><html><body>Sign in to Slack</body></html>"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("xoxc-expired", "stale-cookie")
+	var buf bytes.Buffer
+	err := c.DownloadFile(context.Background(), srv.URL+"/shot.png", &buf)
+	if err == nil {
+		t.Fatal("expected error for HTML login page")
+	}
+	if !strings.Contains(err.Error(), "obk slack auth login") {
+		t.Errorf("error should point at re-auth, got: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("nothing should be written on auth failure, got %d bytes", buf.Len())
+	}
+}
+
+func TestClient_DownloadFile_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewClient("xoxp-test-token", "")
+	var buf bytes.Buffer
+	if err := c.DownloadFile(context.Background(), srv.URL+"/missing.png", &buf); err == nil {
+		t.Fatal("expected error for HTTP 404")
 	}
 }
 

--- a/source/slack/client_test.go
+++ b/source/slack/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -252,6 +253,97 @@ func TestClient_ConversationsReplies(t *testing.T) {
 	}
 	if msgs[1].Text != "reply" {
 		t.Errorf("reply text = %q", msgs[1].Text)
+	}
+}
+
+func TestClient_ConversationsRepliesAll_Paginates(t *testing.T) {
+	var cursors []string
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		cursor := r.FormValue("cursor")
+		cursors = append(cursors, cursor)
+
+		switch cursor {
+		case "":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"ts": "111.222", "text": "parent"},
+					{"ts": "333.444", "text": "reply 1", "thread_ts": "111.222"},
+				},
+				"has_more":          true,
+				"response_metadata": map[string]any{"next_cursor": "page2"},
+			})
+		case "page2":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"ts": "111.222", "text": "parent"},
+					{"ts": "555.666", "text": "reply 2", "thread_ts": "111.222"},
+				},
+				"response_metadata": map[string]any{"next_cursor": ""},
+			})
+		default:
+			t.Errorf("unexpected cursor %q", cursor)
+		}
+	})
+
+	msgs, err := c.ConversationsRepliesAll(context.Background(), "C123", "111.222", HistoryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Text != "parent" || msgs[1].Text != "reply 1" || msgs[2].Text != "reply 2" {
+		t.Errorf("messages = %+v", msgs)
+	}
+	if len(cursors) != 2 || cursors[1] != "page2" {
+		t.Errorf("cursors = %v", cursors)
+	}
+}
+
+func TestClient_ConversationsRepliesAll_SinglePage(t *testing.T) {
+	var calls atomic.Int32
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": []map[string]any{
+				{"ts": "111.222", "text": "parent"},
+			},
+		})
+	})
+
+	msgs, err := c.ConversationsRepliesAll(context.Background(), "C123", "111.222", HistoryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected 1 call, got %d", calls.Load())
+	}
+}
+
+func TestClient_ConversationsRepliesAll_PreservesAttachments(t *testing.T) {
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ok":true,"messages":[
+			{"ts":"111.222","text":"","bot_id":"B01","username":"Sentry",
+			 "attachments":[{"title":"PaymentFailed","text":"500 from upstream"}]}
+		]}`))
+	})
+
+	msgs, err := c.ConversationsRepliesAll(context.Background(), "C123", "111.222", HistoryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !strings.Contains(string(msgs[0].Attachments), "PaymentFailed") {
+		t.Errorf("attachments = %s", msgs[0].Attachments)
 	}
 }
 

--- a/source/slack/client_test.go
+++ b/source/slack/client_test.go
@@ -549,6 +549,30 @@ func TestClient_DownloadFile_HTTPError(t *testing.T) {
 	}
 }
 
+func TestClient_GetPermalink(t *testing.T) {
+	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.FormValue("channel") != "C123" {
+			t.Errorf("channel = %q", r.FormValue("channel"))
+		}
+		if r.FormValue("message_ts") != "1785334150.236249" {
+			t.Errorf("message_ts = %q", r.FormValue("message_ts"))
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":        true,
+			"permalink": "https://acme.slack.com/archives/C123/p1785334150236249",
+		})
+	})
+
+	link, err := c.GetPermalink(context.Background(), "C123", "1785334150.236249")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != "https://acme.slack.com/archives/C123/p1785334150236249" {
+		t.Errorf("permalink = %q", link)
+	}
+}
+
 func TestClient_UpdateMessage(t *testing.T) {
 	c := testServer(t, func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()

--- a/source/slack/media.go
+++ b/source/slack/media.go
@@ -1,0 +1,46 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// filePermalinkRe matches the file ID in /files/U02ABC/F0BLMEDEJCS/name.png.
+var filePermalinkRe = regexp.MustCompile(`/files/[^/]+/(F[A-Z0-9]+)`)
+
+// ResolveFileURL turns a Slack file reference into a URL that serves the file
+// bytes. A files.slack.com url_private is already one; a /files/… permalink is
+// an HTML page, so its file ID is looked up via files.info.
+func ResolveFileURL(ctx context.Context, api API, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("not a Slack file URL: %q (want a url_private or a /files/… permalink)", raw)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if host == "files.slack.com" {
+		return raw, nil
+	}
+	if !strings.HasSuffix(host, ".slack.com") {
+		return "", fmt.Errorf("not a Slack file URL: %q (want a url_private or a /files/… permalink)", raw)
+	}
+
+	m := filePermalinkRe.FindStringSubmatch(u.Path)
+	if m == nil {
+		return "", fmt.Errorf("no file ID in %q (want /files/<user>/<file-id>/<name>)", raw)
+	}
+
+	f, err := api.FilesInfo(ctx, m[1])
+	if err != nil {
+		return "", fmt.Errorf("file info %s: %w", m[1], err)
+	}
+	if f.URLPrivate == "" {
+		return "", fmt.Errorf("file %s has no downloadable URL", m[1])
+	}
+	return f.URLPrivate, nil
+}

--- a/source/slack/media_test.go
+++ b/source/slack/media_test.go
@@ -1,0 +1,95 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fileAPI struct {
+	mockAPI
+	file        *File
+	err         error
+	requestedID string
+}
+
+func (a *fileAPI) FilesInfo(_ context.Context, id string) (*File, error) {
+	a.requestedID = id
+	if a.err != nil {
+		return nil, a.err
+	}
+	return a.file, nil
+}
+
+func TestResolveFileURL_URLPrivatePassesThrough(t *testing.T) {
+	api := &fileAPI{}
+	raw := "https://files.slack.com/files-pri/T436FEDD0-F0BLMEDEJCS/file__1_.jpg"
+
+	got, err := ResolveFileURL(context.Background(), api, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != raw {
+		t.Errorf("got %q, want %q", got, raw)
+	}
+	if api.requestedID != "" {
+		t.Errorf("url_private should not need files.info, looked up %q", api.requestedID)
+	}
+}
+
+// A /files/… permalink serves an HTML page, so it must go through files.info.
+func TestResolveFileURL_PermalinkLooksUpFileInfo(t *testing.T) {
+	api := &fileAPI{file: &File{
+		ID:         "F0BLMEDEJCS",
+		URLPrivate: "https://files.slack.com/files-pri/T436FEDD0-F0BLMEDEJCS/file__1_.jpg",
+	}}
+
+	got, err := ResolveFileURL(context.Background(), api,
+		"https://okcredit.slack.com/files/U02CMP7DXU1/F0BLMEDEJCS/file__1_.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.requestedID != "F0BLMEDEJCS" {
+		t.Errorf("looked up %q", api.requestedID)
+	}
+	if got != api.file.URLPrivate {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolveFileURL_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"bare file id", "F0BLMEDEJCS"},
+		{"empty", ""},
+		{"non-slack host", "https://example.com/files/U1/F123/x.png"},
+		{"slack host without file path", "https://okcredit.slack.com/archives/C01/p1785334150236249"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ResolveFileURL(context.Background(), &fileAPI{}, tc.raw); err == nil {
+				t.Fatalf("expected error for %q", tc.raw)
+			}
+		})
+	}
+}
+
+func TestResolveFileURL_FileInfoError(t *testing.T) {
+	api := &fileAPI{err: errors.New("file_not_found")}
+	_, err := ResolveFileURL(context.Background(), api,
+		"https://okcredit.slack.com/files/U02CMP7DXU1/F0BLMEDEJCS/file.jpg")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestResolveFileURL_NoDownloadableURL(t *testing.T) {
+	api := &fileAPI{file: &File{ID: "F1"}}
+	_, err := ResolveFileURL(context.Background(), api,
+		"https://okcredit.slack.com/files/U02CMP7DXU1/F1/file.jpg")
+	if err == nil {
+		t.Fatal("expected error when the file has no url_private")
+	}
+}

--- a/source/slack/ref.go
+++ b/source/slack/ref.go
@@ -1,0 +1,143 @@
+package slack
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MessageRef identifies a single Slack message parsed from a permalink.
+type MessageRef struct {
+	ChannelID string // C…/G…/D…
+	MessageID string // p-form, e.g. p1785319451036269
+	ThreadTS  string // dotted root ts from ?thread_ts=, empty if absent
+	Subdomain string // "okcredit", from the permalink host
+}
+
+// TS returns the dotted timestamp of the referenced message.
+func (r *MessageRef) TS() (string, error) {
+	return MessageIDToTS(r.MessageID)
+}
+
+// RootTS returns the thread root timestamp: the permalink's thread_ts when
+// present, otherwise the message's own timestamp.
+func (r *MessageRef) RootTS() (string, error) {
+	if r.ThreadTS != "" {
+		return MessageIDToTS(r.ThreadTS)
+	}
+	return MessageIDToTS(r.MessageID)
+}
+
+// ParsePermalink parses a Slack message permalink into its parts.
+func ParsePermalink(raw string) (*MessageRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("empty permalink")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse permalink %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("not a Slack permalink: %q", raw)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if !strings.HasSuffix(host, ".slack.com") {
+		return nil, fmt.Errorf("not a Slack permalink: %q", raw)
+	}
+	subdomain, _, _ := strings.Cut(host, ".")
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 3 || parts[0] != "archives" {
+		return nil, fmt.Errorf("permalink %q is missing /archives/<channel>/<message>", raw)
+	}
+
+	channelID := parts[1]
+	if !isChannelID(channelID) {
+		return nil, fmt.Errorf("invalid channel ID %q in permalink", channelID)
+	}
+
+	ts, err := MessageIDToTS(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("permalink %q: %w", raw, err)
+	}
+
+	ref := &MessageRef{
+		ChannelID: channelID,
+		MessageID: TSToMessageID(ts),
+		Subdomain: subdomain,
+	}
+
+	if threadTS := u.Query().Get("thread_ts"); threadTS != "" {
+		root, err := MessageIDToTS(threadTS)
+		if err != nil {
+			return nil, fmt.Errorf("permalink %q thread_ts: %w", raw, err)
+		}
+		ref.ThreadTS = root
+	}
+	return ref, nil
+}
+
+// MessageIDToTS converts a p-form message ID to a dotted timestamp:
+// p1785319451036269 -> 1785319451.036269. A dotted timestamp is accepted
+// and returned unchanged, so callers can pass either form.
+func MessageIDToTS(id string) (string, error) {
+	s := strings.TrimSpace(id)
+	if s == "" {
+		return "", fmt.Errorf("empty message ID")
+	}
+
+	if seconds, micros, ok := strings.Cut(s, "."); ok {
+		seconds = strings.TrimPrefix(seconds, "p")
+		if !allDigits(seconds) || !allDigits(micros) {
+			return "", fmt.Errorf("invalid timestamp %q", id)
+		}
+		return seconds + "." + micros, nil
+	}
+
+	digits := strings.TrimPrefix(s, "p")
+	if !allDigits(digits) || len(digits) <= 6 {
+		return "", fmt.Errorf("invalid message ID %q (want p1785319451036269)", id)
+	}
+	return digits[:len(digits)-6] + "." + digits[len(digits)-6:], nil
+}
+
+// TSToMessageID converts a dotted timestamp to the p-form used in permalinks.
+func TSToMessageID(ts string) string {
+	s := strings.TrimPrefix(strings.TrimSpace(ts), "p")
+	return "p" + strings.ReplaceAll(s, ".", "")
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchesWorkspace reports whether a permalink subdomain plausibly refers to
+// the given workspace name. Comparison ignores case and separators, so the
+// team name "OkCredit" matches the subdomain "okcredit".
+func MatchesWorkspace(subdomain, workspace string) bool {
+	if subdomain == "" || workspace == "" {
+		return true
+	}
+	return normalizeWorkspace(subdomain) == normalizeWorkspace(workspace)
+}
+
+func normalizeWorkspace(s string) string {
+	var b strings.Builder
+	for _, c := range strings.ToLower(s) {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}

--- a/source/slack/ref_test.go
+++ b/source/slack/ref_test.go
@@ -1,0 +1,181 @@
+package slack
+
+import "testing"
+
+func TestParsePermalink_Basic(t *testing.T) {
+	ref, err := ParsePermalink("https://okcredit.slack.com/archives/C01Q9G9CD6X/p1785334150236249")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.ChannelID != "C01Q9G9CD6X" {
+		t.Errorf("channel = %q", ref.ChannelID)
+	}
+	if ref.MessageID != "p1785334150236249" {
+		t.Errorf("message = %q", ref.MessageID)
+	}
+	if ref.ThreadTS != "" {
+		t.Errorf("thread_ts = %q, want empty", ref.ThreadTS)
+	}
+	if ref.Subdomain != "okcredit" {
+		t.Errorf("subdomain = %q", ref.Subdomain)
+	}
+
+	root, err := ref.RootTS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "1785334150.236249" {
+		t.Errorf("root = %q", root)
+	}
+}
+
+func TestParsePermalink_ReplyWithThreadTS(t *testing.T) {
+	raw := "https://okcredit.slack.com/archives/C094FL95GDV/p1785319451036269?thread_ts=1785319311.419309&cid=C094FL95GDV"
+	ref, err := ParsePermalink(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.MessageID != "p1785319451036269" {
+		t.Errorf("message = %q", ref.MessageID)
+	}
+	if ref.ThreadTS != "1785319311.419309" {
+		t.Errorf("thread_ts = %q", ref.ThreadTS)
+	}
+
+	// The root is the thread_ts, not the message's own ts.
+	root, err := ref.RootTS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "1785319311.419309" {
+		t.Errorf("root = %q", root)
+	}
+	ts, err := ref.TS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts != "1785319451.036269" {
+		t.Errorf("ts = %q", ts)
+	}
+}
+
+func TestParsePermalink_DM(t *testing.T) {
+	ref, err := ParsePermalink("https://okcredit.slack.com/archives/D01ABC23DEF/p1785334150236249")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.ChannelID != "D01ABC23DEF" {
+		t.Errorf("channel = %q", ref.ChannelID)
+	}
+}
+
+func TestParsePermalink_PrivateGroup(t *testing.T) {
+	ref, err := ParsePermalink("https://okcredit.slack.com/archives/G01ABC23DEF/p1785334150236249")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.ChannelID != "G01ABC23DEF" {
+		t.Errorf("channel = %q", ref.ChannelID)
+	}
+}
+
+func TestParsePermalink_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty", ""},
+		{"not a url", "hello world"},
+		{"wrong host", "https://example.com/archives/C123/p1785334150236249"},
+		{"no archives segment", "https://okcredit.slack.com/messages/C123/p1785334150236249"},
+		{"missing message", "https://okcredit.slack.com/archives/C01Q9G9CD6X"},
+		{"bad channel id", "https://okcredit.slack.com/archives/X01Q9G/p1785334150236249"},
+		{"bad message id", "https://okcredit.slack.com/archives/C01Q9G9CD6X/pnotanumber"},
+		{"message id too short", "https://okcredit.slack.com/archives/C01Q9G9CD6X/p12345"},
+		{"bad thread_ts", "https://okcredit.slack.com/archives/C01Q9G9CD6X/p1785334150236249?thread_ts=abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParsePermalink(tc.raw); err == nil {
+				t.Fatalf("expected error for %q", tc.raw)
+			}
+		})
+	}
+}
+
+func TestMessageIDToTS(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"p1785334150236249", "1785334150.236249"},
+		{"1785334150.236249", "1785334150.236249"},
+		{"p1785334150.236249", "1785334150.236249"},
+		{"1785334150236249", "1785334150.236249"},
+	}
+	for _, tc := range cases {
+		got, err := MessageIDToTS(tc.in)
+		if err != nil {
+			t.Fatalf("%q: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("MessageIDToTS(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMessageIDToTS_Invalid(t *testing.T) {
+	for _, in := range []string{"", "p", "pabc", "p12345", "1785334150.", ".236249", "17853x4150.236249"} {
+		if got, err := MessageIDToTS(in); err == nil {
+			t.Errorf("MessageIDToTS(%q) = %q, want error", in, got)
+		}
+	}
+}
+
+func TestTSToMessageID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1785334150.236249", "p1785334150236249"},
+		{"p1785334150236249", "p1785334150236249"},
+	}
+	for _, tc := range cases {
+		if got := TSToMessageID(tc.in); got != tc.want {
+			t.Errorf("TSToMessageID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMessageIDTSRoundTrip(t *testing.T) {
+	for _, id := range []string{"p1785334150236249", "p1785319451036269", "p1000000000000001"} {
+		ts, err := MessageIDToTS(id)
+		if err != nil {
+			t.Fatalf("%q: %v", id, err)
+		}
+		if got := TSToMessageID(ts); got != id {
+			t.Errorf("round trip %q -> %q -> %q", id, ts, got)
+		}
+	}
+}
+
+func TestMatchesWorkspace(t *testing.T) {
+	cases := []struct {
+		subdomain string
+		workspace string
+		want      bool
+	}{
+		{"okcredit", "okcredit", true},
+		{"okcredit", "OkCredit", true},
+		{"acmecorp", "Acme Corp", true},
+		{"acme-corp", "Acme Corp", true},
+		{"okcredit", "otherteam", false},
+		{"", "okcredit", true},
+		{"okcredit", "", true},
+	}
+	for _, tc := range cases {
+		if got := MatchesWorkspace(tc.subdomain, tc.workspace); got != tc.want {
+			t.Errorf("MatchesWorkspace(%q, %q) = %v, want %v", tc.subdomain, tc.workspace, got, tc.want)
+		}
+	}
+}

--- a/source/slack/resolve.go
+++ b/source/slack/resolve.go
@@ -25,7 +25,7 @@ func NewResolver(api API) *Resolver {
 func (r *Resolver) ResolveChannel(ctx context.Context, ref string) (string, error) {
 	ref = strings.TrimSpace(ref)
 
-	// Already a channel ID (C/G prefix + alphanumeric).
+	// Already a channel ID (C/G/D prefix + alphanumeric).
 	if isChannelID(ref) {
 		return ref, nil
 	}
@@ -111,7 +111,7 @@ func isChannelID(s string) bool {
 	if len(s) < 2 {
 		return false
 	}
-	if s[0] != 'C' && s[0] != 'G' {
+	if s[0] != 'C' && s[0] != 'G' && s[0] != 'D' {
 		return false
 	}
 	for _, c := range s[1:] {

--- a/source/slack/resolve_test.go
+++ b/source/slack/resolve_test.go
@@ -76,6 +76,28 @@ func TestResolveChannel_URL(t *testing.T) {
 	}
 }
 
+func TestResolveChannel_DMID(t *testing.T) {
+	r := NewResolver(&mockAPI{})
+	id, err := r.ResolveChannel(context.Background(), "D0123ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "D0123ABC" {
+		t.Errorf("got %q", id)
+	}
+}
+
+func TestResolveChannel_GroupID(t *testing.T) {
+	r := NewResolver(&mockAPI{})
+	id, err := r.ResolveChannel(context.Background(), "G0123ABC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "G0123ABC" {
+		t.Errorf("got %q", id)
+	}
+}
+
 func TestResolveChannel_NotFound(t *testing.T) {
 	r := NewResolver(&mockAPI{channels: []Channel{}})
 	_, err := r.ResolveChannel(context.Background(), "#nonexistent")

--- a/source/slack/resolve_test.go
+++ b/source/slack/resolve_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"io"
 	"testing"
 )
 
@@ -22,12 +23,24 @@ func (m *mockAPI) ConversationsHistory(context.Context, string, HistoryOptions) 
 func (m *mockAPI) ConversationsReplies(context.Context, string, string, HistoryOptions) ([]Message, error) {
 	return nil, nil
 }
+func (m *mockAPI) ConversationsRepliesAll(context.Context, string, string, HistoryOptions) ([]Message, error) {
+	return nil, nil
+}
 func (m *mockAPI) ConversationsList(context.Context) ([]Channel, error) {
 	return m.channels, nil
 }
 func (m *mockAPI) UsersList(context.Context) ([]User, error) { return m.users, nil }
 func (m *mockAPI) UsersInfo(context.Context, string) (*User, error) {
 	return nil, nil
+}
+func (m *mockAPI) BotsInfo(context.Context, string) (*Bot, error) {
+	return nil, nil
+}
+func (m *mockAPI) FilesInfo(context.Context, string) (*File, error) {
+	return nil, nil
+}
+func (m *mockAPI) DownloadFile(context.Context, string, io.Writer) error {
+	return nil
 }
 func (m *mockAPI) PostMessage(context.Context, string, string, string) (string, error) {
 	return "", nil

--- a/source/slack/thread.go
+++ b/source/slack/thread.go
@@ -1,0 +1,118 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+// Thread is a complete Slack thread with every referenced ID resolved to a name.
+type Thread struct {
+	ChannelID string            `json:"channel_id"`
+	ThreadID  string            `json:"thread_id"`
+	ThreadTS  string            `json:"thread_ts"`
+	Users     map[string]string `json:"users,omitempty"`
+	Messages  []Message         `json:"messages"`
+}
+
+// mentionRe matches <@U123>, <@U123|name>, and the bot form <@B123>.
+var mentionRe = regexp.MustCompile(`<@([UWB][A-Z0-9]+)[|>]`)
+
+// FetchThread returns the whole thread containing ts, regardless of whether ts
+// names the root or a reply. Passing cache as nil skips name resolution.
+func FetchThread(ctx context.Context, api API, cache *UserCache, channelID, ts string) (*Thread, error) {
+	rootTS, err := MessageIDToTS(ts)
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := api.ConversationsRepliesAll(ctx, channelID, rootTS, HistoryOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("fetch thread: %w", err)
+	}
+
+	// Asking for a reply returns that reply pointing at the real root; follow it.
+	if len(msgs) > 0 && msgs[0].ThreadTS != "" && msgs[0].ThreadTS != rootTS {
+		rootTS = msgs[0].ThreadTS
+		msgs, err = api.ConversationsRepliesAll(ctx, channelID, rootTS, HistoryOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("fetch thread root: %w", err)
+		}
+	}
+
+	thread := &Thread{
+		ChannelID: channelID,
+		ThreadID:  TSToMessageID(rootTS),
+		ThreadTS:  rootTS,
+		Messages:  msgs,
+	}
+
+	names := resolveNames(ctx, cache, msgs)
+	for i := range thread.Messages {
+		m := &thread.Messages[i]
+		m.MessageID = TSToMessageID(m.TS)
+		if name, ok := names[m.User]; ok && m.User != "" {
+			m.UserName = name
+		} else if name, ok := names[m.BotID]; ok && m.BotID != "" {
+			m.UserName = name
+		}
+	}
+	if len(names) > 0 {
+		thread.Users = names
+	}
+	return thread, nil
+}
+
+// resolveNames looks up every ID the thread references: authors, in-text
+// mentions, reaction voters, editors, and bots. The users map is the only way
+// to resolve an ID, since message text is left raw, so a partial map would
+// leave IDs dangling.
+func resolveNames(ctx context.Context, cache *UserCache, msgs []Message) map[string]string {
+	if cache == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var ids []string
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+
+	for _, m := range msgs {
+		// A bot's own message carries its display name; seeding avoids bots.info.
+		if m.BotID != "" && m.Username != "" {
+			cache.Seed(m.BotID, m.Username)
+		}
+		add(m.User)
+		add(m.BotID)
+		if m.Edited != nil {
+			add(m.Edited.User)
+		}
+		for _, r := range m.Reactions {
+			for _, u := range r.Users {
+				add(u)
+			}
+		}
+		for _, match := range mentionRe.FindAllStringSubmatch(m.Text, -1) {
+			add(match[1])
+		}
+		for _, match := range mentionRe.FindAllStringSubmatch(string(m.Attachments), -1) {
+			add(match[1])
+		}
+		for _, match := range mentionRe.FindAllStringSubmatch(string(m.Blocks), -1) {
+			add(match[1])
+		}
+	}
+
+	sort.Strings(ids)
+	names, err := cache.Names(ctx, ids)
+	if err != nil {
+		return nil
+	}
+	return names
+}

--- a/source/slack/thread.go
+++ b/source/slack/thread.go
@@ -33,8 +33,8 @@ func FetchThread(ctx context.Context, api API, cache *UserCache, channelID, ts s
 	}
 
 	// Asking for a reply returns that reply pointing at the real root; follow it.
-	if len(msgs) > 0 && msgs[0].ThreadTS != "" && msgs[0].ThreadTS != rootTS {
-		rootTS = msgs[0].ThreadTS
+	if root := rootOf(msgs, rootTS); root != rootTS {
+		rootTS = root
 		msgs, err = api.ConversationsRepliesAll(ctx, channelID, rootTS, HistoryOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("fetch thread root: %w", err)
@@ -62,6 +62,28 @@ func FetchThread(ctx context.Context, api API, cache *UserCache, channelID, ts s
 		thread.Users = names
 	}
 	return thread, nil
+}
+
+// ResolveThreadRoot returns the root timestamp of the thread containing ts.
+// Writers need it because Slack expects a thread's parent ts, not a reply's.
+func ResolveThreadRoot(ctx context.Context, api API, channelID, ts string) (string, error) {
+	askedTS, err := MessageIDToTS(ts)
+	if err != nil {
+		return "", err
+	}
+	msgs, err := api.ConversationsReplies(ctx, channelID, askedTS, HistoryOptions{Limit: 1})
+	if err != nil {
+		return "", fmt.Errorf("resolve thread root: %w", err)
+	}
+	return rootOf(msgs, askedTS), nil
+}
+
+// rootOf reads the real thread root off the first message returned for askedTS.
+func rootOf(msgs []Message, askedTS string) string {
+	if len(msgs) > 0 && msgs[0].ThreadTS != "" && msgs[0].ThreadTS != askedTS {
+		return msgs[0].ThreadTS
+	}
+	return askedTS
 }
 
 // resolveNames looks up every ID the thread references: authors, in-text

--- a/source/slack/thread_test.go
+++ b/source/slack/thread_test.go
@@ -1,0 +1,243 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type threadAPI struct {
+	userCacheAPI
+	byTS      map[string][]Message
+	requested []string
+	err       error
+}
+
+func (a *threadAPI) ConversationsRepliesAll(_ context.Context, _ string, ts string, _ HistoryOptions) ([]Message, error) {
+	a.requested = append(a.requested, ts)
+	if a.err != nil {
+		return nil, a.err
+	}
+	return a.byTS[ts], nil
+}
+
+func TestFetchThread_Basic(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			"1785334150.236249": {
+				{TS: "1785334150.236249", User: "U1", Text: "customer cannot settle"},
+				{TS: "1785334200.111111", User: "U2", Text: "looking", ThreadTS: "1785334150.236249"},
+			},
+		},
+	}
+	api.users = map[string]*User{
+		"U1": {ID: "U1", Profile: &UserProfile{DisplayName: "rahul.support"}},
+		"U2": {ID: "U2", Profile: &UserProfile{DisplayName: "priya.eng"}},
+	}
+
+	th, err := FetchThread(context.Background(), api, NewUserCache("okcredit", api), "C01", "p1785334150236249")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if th.ChannelID != "C01" {
+		t.Errorf("channel = %q", th.ChannelID)
+	}
+	if th.ThreadID != "p1785334150236249" {
+		t.Errorf("thread_id = %q", th.ThreadID)
+	}
+	if th.ThreadTS != "1785334150.236249" {
+		t.Errorf("thread_ts = %q", th.ThreadTS)
+	}
+	if len(th.Messages) != 2 {
+		t.Fatalf("messages = %d", len(th.Messages))
+	}
+	if th.Messages[0].MessageID != "p1785334150236249" {
+		t.Errorf("message_id = %q", th.Messages[0].MessageID)
+	}
+	if th.Messages[0].UserName != "rahul.support" || th.Messages[1].UserName != "priya.eng" {
+		t.Errorf("user names = %q / %q", th.Messages[0].UserName, th.Messages[1].UserName)
+	}
+	if th.Users["U2"] != "priya.eng" {
+		t.Errorf("users map = %+v", th.Users)
+	}
+}
+
+// A permalink to a reply resolves to the whole thread, not just that message.
+func TestFetchThread_ResolvesRootFromReply(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	root := "1785319311.419309"
+	reply := "1785319451.036269"
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			reply: {
+				{TS: reply, User: "U2", Text: "a reply", ThreadTS: root},
+			},
+			root: {
+				{TS: root, User: "U1", Text: "the root"},
+				{TS: reply, User: "U2", Text: "a reply", ThreadTS: root},
+			},
+		},
+	}
+
+	th, err := FetchThread(context.Background(), api, nil, "C094FL95GDV", "p1785319451036269")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if th.ThreadTS != root {
+		t.Errorf("thread_ts = %q, want root %q", th.ThreadTS, root)
+	}
+	if th.ThreadID != "p1785319311419309" {
+		t.Errorf("thread_id = %q", th.ThreadID)
+	}
+	if len(th.Messages) != 2 {
+		t.Fatalf("expected the full thread, got %d messages", len(th.Messages))
+	}
+	if len(api.requested) != 2 || api.requested[1] != root {
+		t.Errorf("requested = %v", api.requested)
+	}
+}
+
+func TestFetchThread_RootNeedsNoSecondCall(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	root := "1785319311.419309"
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			root: {
+				{TS: root, User: "U1", Text: "the root", ThreadTS: root},
+				{TS: "1785319451.036269", User: "U2", Text: "a reply", ThreadTS: root},
+			},
+		},
+	}
+
+	th, err := FetchThread(context.Background(), api, nil, "C01", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(th.Messages) != 2 {
+		t.Fatalf("messages = %d", len(th.Messages))
+	}
+	if len(api.requested) != 1 {
+		t.Errorf("expected 1 fetch, got %v", api.requested)
+	}
+}
+
+func TestFetchThread_UsersCoversMentionsReactionsAndBots(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			"111.222222": {
+				{
+					TS:   "111.222222",
+					User: "U1",
+					Text: "<@U2> can you check <#C02XY|ledger>? cc <@U3|priya>",
+					Reactions: []Reaction{
+						{Name: "eyes", Users: []string{"U4"}, Count: 1},
+					},
+					Edited: &Edited{User: "U5", TS: "111.333333"},
+				},
+				{
+					TS:          "111.444444",
+					BotID:       "B1",
+					Username:    "Sentry",
+					ThreadTS:    "111.222222",
+					Attachments: json.RawMessage(`[{"text":"paging <@U6>"}]`),
+				},
+			},
+		},
+	}
+	api.users = map[string]*User{
+		"U1": {ID: "U1", Name: "rahul"},
+		"U2": {ID: "U2", Name: "amit"},
+		"U3": {ID: "U3", Name: "priya"},
+		"U4": {ID: "U4", Name: "sneha"},
+		"U5": {ID: "U5", Name: "vikram"},
+		"U6": {ID: "U6", Name: "oncall"},
+	}
+
+	th, err := FetchThread(context.Background(), api, NewUserCache("okcredit", api), "C01", "111.222222")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, id := range []string{"U1", "U2", "U3", "U4", "U5", "U6"} {
+		if th.Users[id] == "" {
+			t.Errorf("users map missing %s: %+v", id, th.Users)
+		}
+	}
+	// Channel refs carry their name inline and are not looked up.
+	if _, ok := th.Users["C02XY"]; ok {
+		t.Error("channel refs should not be in the users map")
+	}
+	// The bot's inline username seeds the cache instead of costing a bots.info call.
+	if th.Users["B1"] != "Sentry" {
+		t.Errorf("B1 = %q", th.Users["B1"])
+	}
+	if api.botCalls != 0 {
+		t.Errorf("bots.info calls = %d, want 0", api.botCalls)
+	}
+	if th.Messages[1].UserName != "Sentry" {
+		t.Errorf("bot message user_name = %q", th.Messages[1].UserName)
+	}
+	// Text is left raw so the caller sees exactly what Slack stored.
+	if th.Messages[0].Text != "<@U2> can you check <#C02XY|ledger>? cc <@U3|priya>" {
+		t.Errorf("text was rewritten: %q", th.Messages[0].Text)
+	}
+}
+
+func TestFetchThread_NilCacheSkipsNames(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			"111.222222": {{TS: "111.222222", User: "U1", Text: "hi"}},
+		},
+	}
+
+	th, err := FetchThread(context.Background(), api, nil, "C01", "111.222222")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if th.Users != nil {
+		t.Errorf("users = %+v, want nil", th.Users)
+	}
+	if th.Messages[0].UserName != "" {
+		t.Errorf("user_name = %q, want empty", th.Messages[0].UserName)
+	}
+	if th.Messages[0].MessageID != "p111222222" {
+		t.Errorf("message_id = %q", th.Messages[0].MessageID)
+	}
+}
+
+func TestFetchThread_InvalidTS(t *testing.T) {
+	if _, err := FetchThread(context.Background(), &threadAPI{}, nil, "C01", "not-a-ts"); err == nil {
+		t.Fatal("expected error for malformed timestamp")
+	}
+}
+
+func TestFetchThread_APIError(t *testing.T) {
+	api := &threadAPI{err: errors.New("channel_not_found")}
+	if _, err := FetchThread(context.Background(), api, nil, "C01", "111.222222"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFetchThread_UnresolvedNamesAreNotFatal(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			"111.222222": {{TS: "111.222222", User: "U404", Text: "hi"}},
+		},
+	}
+
+	th, err := FetchThread(context.Background(), api, NewUserCache("okcredit", api), "C01", "111.222222")
+	if err != nil {
+		t.Fatalf("name lookup failure must not fail the fetch: %v", err)
+	}
+	if th.Messages[0].UserName != "" {
+		t.Errorf("user_name = %q, want empty", th.Messages[0].UserName)
+	}
+	if th.Messages[0].Text != "hi" {
+		t.Errorf("text = %q", th.Messages[0].Text)
+	}
+}

--- a/source/slack/thread_test.go
+++ b/source/slack/thread_test.go
@@ -22,6 +22,14 @@ func (a *threadAPI) ConversationsRepliesAll(_ context.Context, _ string, ts stri
 	return a.byTS[ts], nil
 }
 
+func (a *threadAPI) ConversationsReplies(_ context.Context, _ string, ts string, _ HistoryOptions) ([]Message, error) {
+	a.requested = append(a.requested, ts)
+	if a.err != nil {
+		return nil, a.err
+	}
+	return a.byTS[ts], nil
+}
+
 func TestFetchThread_Basic(t *testing.T) {
 	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
 	api := &threadAPI{
@@ -206,6 +214,39 @@ func TestFetchThread_NilCacheSkipsNames(t *testing.T) {
 	}
 	if th.Messages[0].MessageID != "p111222222" {
 		t.Errorf("message_id = %q", th.Messages[0].MessageID)
+	}
+}
+
+func TestResolveThreadRoot(t *testing.T) {
+	root := "1785319311.419309"
+	reply := "1785319451.036269"
+	api := &threadAPI{
+		byTS: map[string][]Message{
+			reply: {{TS: reply, ThreadTS: root, Text: "a reply"}},
+			root:  {{TS: root, Text: "the root"}},
+		},
+	}
+
+	got, err := ResolveThreadRoot(context.Background(), api, "C01", "p1785319451036269")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != root {
+		t.Errorf("got %q, want %q", got, root)
+	}
+
+	got, err = ResolveThreadRoot(context.Background(), api, "C01", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != root {
+		t.Errorf("root should resolve to itself, got %q", got)
+	}
+}
+
+func TestResolveThreadRoot_InvalidTS(t *testing.T) {
+	if _, err := ResolveThreadRoot(context.Background(), &threadAPI{}, "C01", "nope"); err == nil {
+		t.Fatal("expected error for malformed timestamp")
 	}
 }
 

--- a/source/slack/types.go
+++ b/source/slack/types.go
@@ -1,16 +1,37 @@
 package slack
 
+import "encoding/json"
+
 type Message struct {
-	TS         string      `json:"ts"`
-	User       string      `json:"user,omitempty"`
-	Text       string      `json:"text"`
-	ThreadTS   string      `json:"thread_ts,omitempty"`
-	ReplyCount int         `json:"reply_count,omitempty"`
-	Reactions  []Reaction  `json:"reactions,omitempty"`
-	Files      []File      `json:"files,omitempty"`
-	Username   string      `json:"username,omitempty"`
-	BotID      string      `json:"bot_id,omitempty"`
-	SubType    string      `json:"subtype,omitempty"`
+	TS          string          `json:"ts"`
+	User        string          `json:"user,omitempty"`
+	Text        string          `json:"text"`
+	ThreadTS    string          `json:"thread_ts,omitempty"`
+	ReplyCount  int             `json:"reply_count,omitempty"`
+	Reactions   []Reaction      `json:"reactions,omitempty"`
+	Files       []File          `json:"files,omitempty"`
+	Username    string          `json:"username,omitempty"`
+	BotID       string          `json:"bot_id,omitempty"`
+	SubType     string          `json:"subtype,omitempty"`
+	Blocks      json.RawMessage `json:"blocks,omitempty"`
+	Attachments json.RawMessage `json:"attachments,omitempty"`
+	Edited      *Edited         `json:"edited,omitempty"`
+
+	// Derived on output, never sent by Slack.
+	MessageID string `json:"message_id,omitempty"`
+	UserName  string `json:"user_name,omitempty"`
+}
+
+type Edited struct {
+	User string `json:"user,omitempty"`
+	TS   string `json:"ts,omitempty"`
+}
+
+type Bot struct {
+	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
+	AppID  string `json:"app_id,omitempty"`
+	UserID string `json:"user_id,omitempty"`
 }
 
 type Reaction struct {
@@ -20,14 +41,14 @@ type Reaction struct {
 }
 
 type Channel struct {
-	ID         string  `json:"id"`
-	Name       string  `json:"name"`
-	IsPrivate  bool    `json:"is_private,omitempty"`
-	NumMembers int     `json:"num_members,omitempty"`
-	Topic      *Topic  `json:"topic,omitempty"`
-	Purpose    *Topic  `json:"purpose,omitempty"`
-	IsMember   bool    `json:"is_member,omitempty"`
-	IsArchived bool    `json:"is_archived,omitempty"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsPrivate  bool   `json:"is_private,omitempty"`
+	NumMembers int    `json:"num_members,omitempty"`
+	Topic      *Topic `json:"topic,omitempty"`
+	Purpose    *Topic `json:"purpose,omitempty"`
+	IsMember   bool   `json:"is_member,omitempty"`
+	IsArchived bool   `json:"is_archived,omitempty"`
 }
 
 type Topic struct {
@@ -51,11 +72,16 @@ type UserProfile struct {
 }
 
 type File struct {
-	ID         string `json:"id"`
-	Name       string `json:"name,omitempty"`
-	FileType   string `json:"filetype,omitempty"`
-	URLPrivate string `json:"url_private,omitempty"`
-	Size       int    `json:"size,omitempty"`
+	ID                 string `json:"id"`
+	Name               string `json:"name,omitempty"`
+	FileType           string `json:"filetype,omitempty"`
+	Mimetype           string `json:"mimetype,omitempty"`
+	URLPrivate         string `json:"url_private,omitempty"`
+	URLPrivateDownload string `json:"url_private_download,omitempty"`
+	Permalink          string `json:"permalink,omitempty"`
+	Preview            string `json:"preview,omitempty"`
+	PlainText          string `json:"plain_text,omitempty"`
+	Size               int    `json:"size,omitempty"`
 }
 
 type SearchOptions struct {

--- a/source/slack/types_test.go
+++ b/source/slack/types_test.go
@@ -1,0 +1,90 @@
+package slack
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMessage_PreservesBlocksAndAttachments(t *testing.T) {
+	raw := `{
+		"ts": "1785334150.236249",
+		"user": "U02ABC",
+		"text": "Alert fired",
+		"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*boom*"}}],
+		"attachments": [{"color": "danger", "title": "PaymentFailed", "text": "500 from upstream"}],
+		"edited": {"user": "U02ABC", "ts": "1785334200.000000"}
+	}`
+
+	var msg Message
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(msg.Blocks) == 0 {
+		t.Fatal("blocks dropped")
+	}
+	if !strings.Contains(string(msg.Attachments), "PaymentFailed") {
+		t.Errorf("attachments = %s", msg.Attachments)
+	}
+	if msg.Edited == nil || msg.Edited.TS != "1785334200.000000" {
+		t.Errorf("edited = %+v", msg.Edited)
+	}
+
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"500 from upstream", "mrkdwn", `"edited"`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("round trip lost %q: %s", want, out)
+		}
+	}
+}
+
+func TestMessage_OmitsDerivedAndEmptyFields(t *testing.T) {
+	out, err := json.Marshal(Message{TS: "1.2", Text: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"blocks", "attachments", "edited", "message_id", "user_name"} {
+		if strings.Contains(string(out), unwanted) {
+			t.Errorf("expected %q to be omitted: %s", unwanted, out)
+		}
+	}
+}
+
+func TestFile_ParsesMetadata(t *testing.T) {
+	raw := `{
+		"id": "F123",
+		"name": "screenshot.png",
+		"filetype": "png",
+		"mimetype": "image/png",
+		"url_private": "https://files.slack.com/files-pri/T1-F123/screenshot.png",
+		"url_private_download": "https://files.slack.com/files-pri/T1-F123/download/screenshot.png",
+		"permalink": "https://okcredit.slack.com/files/U02ABC/F123/screenshot.png",
+		"preview": "traceback...",
+		"plain_text": "panic: nil map",
+		"size": 4096
+	}`
+
+	var f File
+	if err := json.Unmarshal([]byte(raw), &f); err != nil {
+		t.Fatal(err)
+	}
+	if f.Mimetype != "image/png" {
+		t.Errorf("mimetype = %q", f.Mimetype)
+	}
+	if f.URLPrivateDownload == "" {
+		t.Error("url_private_download dropped")
+	}
+	if f.Permalink == "" {
+		t.Error("permalink dropped")
+	}
+	if f.Preview != "traceback..." {
+		t.Errorf("preview = %q", f.Preview)
+	}
+	if f.PlainText != "panic: nil map" {
+		t.Errorf("plain_text = %q", f.PlainText)
+	}
+}

--- a/source/slack/usercache.go
+++ b/source/slack/usercache.go
@@ -1,0 +1,189 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/73ai/openbotkit/config"
+)
+
+// UserCache maps Slack IDs to display names, persisted per workspace.
+//
+// It resolves one ID at a time via users.info (Tier 4, ~100/min) rather than
+// paging users.list (Tier 2), because a thread references a handful of people
+// while a large workspace needs dozens of list calls.
+type UserCache struct {
+	workspace string
+	api       API
+
+	mu     sync.Mutex
+	names  map[string]string
+	loaded bool
+	dirty  bool
+}
+
+type cachedUserNames struct {
+	Workspace string            `json:"workspace"`
+	Names     map[string]string `json:"names"`
+}
+
+func NewUserCache(workspace string, api API) *UserCache {
+	return &UserCache{
+		workspace: SanitizeWorkspaceName(workspace),
+		api:       api,
+		names:     make(map[string]string),
+	}
+}
+
+// Refresh discards cached names so the next lookup re-fetches them. The cache
+// file is overwritten on the next save rather than deleted.
+func (c *UserCache) Refresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.names = make(map[string]string)
+	c.loaded = true
+	c.dirty = true
+}
+
+// Seed records a name discovered outside the API, such as the username a bot
+// message carries inline. Existing entries are not overwritten.
+func (c *UserCache) Seed(id, name string) {
+	if id == "" || name == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.load()
+	if _, ok := c.names[id]; ok {
+		return
+	}
+	c.names[id] = name
+	c.dirty = true
+}
+
+// Names resolves ids to display names, fetching only the ones not yet cached.
+// IDs that cannot be resolved are simply absent from the result.
+func (c *UserCache) Names(ctx context.Context, ids []string) (map[string]string, error) {
+	c.mu.Lock()
+	c.load()
+	var missing []string
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := c.names[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	c.mu.Unlock()
+
+	for _, id := range missing {
+		name, ok := c.fetchName(ctx, id)
+		if !ok {
+			continue
+		}
+		c.mu.Lock()
+		c.names[id] = name
+		c.dirty = true
+		c.mu.Unlock()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]string, len(ids))
+	for _, id := range ids {
+		if name, ok := c.names[id]; ok {
+			out[id] = name
+		}
+	}
+	c.save()
+	return out, nil
+}
+
+func (c *UserCache) fetchName(ctx context.Context, id string) (string, bool) {
+	if strings.HasPrefix(id, "B") {
+		bot, err := c.api.BotsInfo(ctx, id)
+		if err != nil || bot == nil || bot.Name == "" {
+			slog.Debug("slack user cache: bot lookup failed", "id", id, "error", err)
+			return "", false
+		}
+		return bot.Name, true
+	}
+
+	user, err := c.api.UsersInfo(ctx, id)
+	if err != nil || user == nil {
+		slog.Debug("slack user cache: user lookup failed", "id", id, "error", err)
+		return "", false
+	}
+	return displayName(user), true
+}
+
+func displayName(u *User) string {
+	if u.Profile != nil {
+		if u.Profile.DisplayName != "" {
+			return u.Profile.DisplayName
+		}
+		if u.Profile.RealName != "" {
+			return u.Profile.RealName
+		}
+	}
+	if u.DisplayName != "" {
+		return u.DisplayName
+	}
+	if u.RealName != "" {
+		return u.RealName
+	}
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.ID
+}
+
+// load reads the cache file once. Callers must hold c.mu.
+func (c *UserCache) load() {
+	if c.loaded {
+		return
+	}
+	c.loaded = true
+
+	data, err := os.ReadFile(c.path())
+	if err != nil {
+		return
+	}
+	var cached cachedUserNames
+	if err := json.Unmarshal(data, &cached); err != nil {
+		slog.Debug("slack user cache: unreadable cache file", "path", c.path(), "error", err)
+		return
+	}
+	maps.Copy(c.names, cached.Names)
+}
+
+// save writes the cache file when there is something new. Callers must hold c.mu.
+func (c *UserCache) save() {
+	if !c.dirty || c.workspace == "" {
+		return
+	}
+	if err := config.EnsureSourceDir("slack"); err != nil {
+		slog.Warn("slack user cache: create dir failed", "error", err)
+		return
+	}
+	data, err := json.MarshalIndent(cachedUserNames{Workspace: c.workspace, Names: c.names}, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(c.path(), data, 0600); err != nil {
+		slog.Warn("slack user cache: write failed", "path", c.path(), "error", err)
+		return
+	}
+	c.dirty = false
+}
+
+func (c *UserCache) path() string {
+	return filepath.Join(config.SourceDir("slack"), "users-"+c.workspace+".json")
+}

--- a/source/slack/usercache_test.go
+++ b/source/slack/usercache_test.go
@@ -1,0 +1,213 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type userCacheAPI struct {
+	mockAPI
+	users     map[string]*User
+	bots      map[string]*Bot
+	userCalls int
+	botCalls  int
+}
+
+func (a *userCacheAPI) UsersInfo(_ context.Context, id string) (*User, error) {
+	a.userCalls++
+	if u, ok := a.users[id]; ok {
+		return u, nil
+	}
+	return nil, errors.New("user_not_found")
+}
+
+func (a *userCacheAPI) BotsInfo(_ context.Context, id string) (*Bot, error) {
+	a.botCalls++
+	if b, ok := a.bots[id]; ok {
+		return b, nil
+	}
+	return nil, errors.New("bot_not_found")
+}
+
+func TestUserCache_ColdMissFetches(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{users: map[string]*User{
+		"U1": {ID: "U1", Name: "rahul", Profile: &UserProfile{DisplayName: "rahul.support"}},
+		"U2": {ID: "U2", Name: "priya"},
+	}}
+
+	c := NewUserCache("okcredit", api)
+	names, err := c.Names(context.Background(), []string{"U1", "U2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["U1"] != "rahul.support" {
+		t.Errorf("U1 = %q", names["U1"])
+	}
+	if names["U2"] != "priya" {
+		t.Errorf("U2 = %q", names["U2"])
+	}
+	if api.userCalls != 2 {
+		t.Errorf("expected 2 users.info calls, got %d", api.userCalls)
+	}
+}
+
+func TestUserCache_WarmHitCostsNothing(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{users: map[string]*User{"U1": {ID: "U1", Name: "rahul"}}}
+
+	c := NewUserCache("okcredit", api)
+	if _, err := c.Names(context.Background(), []string{"U1"}); err != nil {
+		t.Fatal(err)
+	}
+	if api.userCalls != 1 {
+		t.Fatalf("first pass calls = %d", api.userCalls)
+	}
+
+	names, err := c.Names(context.Background(), []string{"U1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["U1"] != "rahul" {
+		t.Errorf("U1 = %q", names["U1"])
+	}
+	if api.userCalls != 1 {
+		t.Errorf("second pass should make no calls, total = %d", api.userCalls)
+	}
+}
+
+func TestUserCache_PersistsAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OBK_CONFIG_DIR", dir)
+	api := &userCacheAPI{users: map[string]*User{"U1": {ID: "U1", Name: "rahul"}}}
+
+	first := NewUserCache("okcredit", api)
+	if _, err := first.Names(context.Background(), []string{"U1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "slack", "users-okcredit.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("cache file mode = %v, want 0600", perm)
+	}
+
+	second := NewUserCache("okcredit", api)
+	names, err := second.Names(context.Background(), []string{"U1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["U1"] != "rahul" {
+		t.Errorf("U1 = %q", names["U1"])
+	}
+	if api.userCalls != 1 {
+		t.Errorf("disk cache should avoid a second call, total = %d", api.userCalls)
+	}
+}
+
+func TestUserCache_Refresh(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{users: map[string]*User{"U1": {ID: "U1", Name: "rahul"}}}
+
+	c := NewUserCache("okcredit", api)
+	if _, err := c.Names(context.Background(), []string{"U1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	c.Refresh()
+	if _, err := c.Names(context.Background(), []string{"U1"}); err != nil {
+		t.Fatal(err)
+	}
+	if api.userCalls != 2 {
+		t.Errorf("refresh should force a re-fetch, calls = %d", api.userCalls)
+	}
+}
+
+func TestUserCache_DisplayNameFallbackChain(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{users: map[string]*User{
+		"U1": {ID: "U1", Name: "handle", RealName: "Real Name", Profile: &UserProfile{DisplayName: "display", RealName: "Profile Real"}},
+		"U2": {ID: "U2", Name: "handle", RealName: "Real Name", Profile: &UserProfile{RealName: "Profile Real"}},
+		"U3": {ID: "U3", Name: "handle", RealName: "Real Name"},
+		"U4": {ID: "U4", Name: "handle"},
+		"U5": {ID: "U5"},
+	}}
+
+	c := NewUserCache("okcredit", api)
+	names, err := c.Names(context.Background(), []string{"U1", "U2", "U3", "U4", "U5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"U1": "display",
+		"U2": "Profile Real",
+		"U3": "Real Name",
+		"U4": "handle",
+		"U5": "U5",
+	}
+	for id, expect := range want {
+		if names[id] != expect {
+			t.Errorf("%s = %q, want %q", id, names[id], expect)
+		}
+	}
+}
+
+func TestUserCache_BotIDsUseBotsInfo(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{bots: map[string]*Bot{"B1": {ID: "B1", Name: "Sentry"}}}
+
+	c := NewUserCache("okcredit", api)
+	names, err := c.Names(context.Background(), []string{"B1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["B1"] != "Sentry" {
+		t.Errorf("B1 = %q", names["B1"])
+	}
+	if api.botCalls != 1 || api.userCalls != 0 {
+		t.Errorf("bot calls = %d, user calls = %d", api.botCalls, api.userCalls)
+	}
+}
+
+func TestUserCache_SeedSkipsLookup(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{}
+
+	c := NewUserCache("okcredit", api)
+	c.Seed("B1", "Alertmanager")
+
+	names, err := c.Names(context.Background(), []string{"B1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["B1"] != "Alertmanager" {
+		t.Errorf("B1 = %q", names["B1"])
+	}
+	if api.botCalls != 0 {
+		t.Errorf("seeded name should not trigger bots.info, calls = %d", api.botCalls)
+	}
+}
+
+func TestUserCache_UnresolvableIDsAreAbsent(t *testing.T) {
+	t.Setenv("OBK_CONFIG_DIR", t.TempDir())
+	api := &userCacheAPI{users: map[string]*User{"U1": {ID: "U1", Name: "rahul"}}}
+
+	c := NewUserCache("okcredit", api)
+	names, err := c.Names(context.Background(), []string{"U1", "U404"})
+	if err != nil {
+		t.Fatalf("lookup failures must not be fatal: %v", err)
+	}
+	if names["U1"] != "rahul" {
+		t.Errorf("U1 = %q", names["U1"])
+	}
+	if _, ok := names["U404"]; ok {
+		t.Errorf("unresolvable ID should be absent, got %q", names["U404"])
+	}
+}


### PR DESCRIPTION
lets you debug a support thread from the cli instead of clicking around slack. obk slack thread <permalink> dumps the whole thread as json with names instead of U02ABC ids, obk slack media download grabs the screenshots (those need cookie auth so they were unreachable before), obk slack reply posts back.

fixed a few things on the way: conversations.replies never followed next_cursor so long threads were silently cut off, we were dropping blocks/attachments/edited off every message so alert bot payloads just vanished, and DM permalinks never worked at all cause isChannelID rejected D ids.

names come from users.info per id and get cached in ~/.obk/slack so repeat runs make zero calls. downloads check content-type first because slack hands you an html login page with a 200 when your cookie is stale, otherwise you just end up with a webpage written into your .png.

agent tools get the same reach, slack_read_thread takes a permalink now and theres a new slack_media_download that saves to scratch so claude can actually look at the screenshot.

also threw in a slack-thread skill so the assistant knows how to use all this without being told. its in skills/slack-thread and registered as a builtin so obk update picks it up.

tested against real okcredit threads, all four addressing forms land on the same root. spectest is still unrun, the gemini key in the keychain is invalid so it dies before it gets anywhere near slack.
